### PR TITLE
Add inbound Candid UI message listener

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -316,6 +316,11 @@ export function App() {
                     ?.candid
                 }
                 forceUpdate={forceUpdate}
+                onMessage={({ origin, source, message }) => {
+                  console.log("Received message from Candid UI:", message);
+                  // TODO: handle messages as needed
+                  // workplaceDispatch({ type: "candid", payload: { message } });
+                }}
               />
             ) : null}
           </AppContainer>

--- a/src/components/CandidUI.tsx
+++ b/src/components/CandidUI.tsx
@@ -3,7 +3,7 @@ import { PanelHeader } from "./shared/PanelHeader";
 import iconCollapse from "../assets/images/icon-collapse.svg";
 import iconOpen from "../assets/images/icon-open.svg";
 import { uiCanisterUrl } from "../config/actor";
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useState, useRef } from "react";
 
 const CandidPanel = styled.div<{ isExpanded: boolean }>`
   width: 40%;
@@ -35,24 +35,74 @@ const Button = styled.button`
 `;
 
 const CANDID_UI_CANISTER_URL = uiCanisterUrl;
+const CANDID_UI_MESSAGE_PREFIX = "CandidUI";
 
-export function CandidUI({ canisterId, candid, setCandidWidth, forceUpdate }) {
+interface PropTypes {
+  canisterId: string;
+  candid?: string | null | undefined;
+  setCandidWidth?: (width: string) => void;
+  forceUpdate?: any;
+  onMessage?: (event: { origin: string; source: Window; message: any }) => void;
+}
+
+export function CandidUI({
+  canisterId,
+  candid,
+  setCandidWidth,
+  forceUpdate,
+  onMessage,
+}: PropTypes) {
   const [isExpanded, setIsExpanded] = useState(true);
+  const candidFrameRef = useRef<HTMLIFrameElement>(null);
   const didParam =
     candid && candid.length < 2048
       ? `&did=${encodeURIComponent(btoa(candid))}`
       : "";
 
+  const url =
+    `${CANDID_UI_CANISTER_URL}/?id=${canisterId}&tag=${forceUpdate}` + didParam;
+
   useEffect(() => {
     const newSize = isExpanded ? "30vw" : "fit-content";
-    setCandidWidth(newSize);
+    setCandidWidth?.(newSize);
   }, [isExpanded, setCandidWidth]);
   useEffect(() => {
     setIsExpanded(true);
   }, [canisterId, candid, forceUpdate]);
+  useEffect(() => {
+    const handleMessage = ({ origin, source, data }) => {
+      const frame = candidFrameRef.current;
+      if (frame) {
+        try {
+          // Validate and parse message (example: `CandidUI{"key":"value",...}`)
+          if (
+            typeof data === "string" &&
+            data.startsWith(CANDID_UI_MESSAGE_PREFIX)
+          ) {
+            // Ensure the message is from Candid UI
+            if (origin !== CANDID_UI_CANISTER_URL) {
+              console.warn(
+                "Received Candid UI message from unexpected origin:",
+                origin,
+                `(Expected: ${CANDID_UI_CANISTER_URL})`
+              );
+              return;
+            }
+            const message = JSON.parse(
+              data.substring(CANDID_UI_MESSAGE_PREFIX.length)
+            );
+            onMessage?.({ origin, source, message });
+          }
+        } catch (e) {
+          console.error("Error while processing Candid UI message:");
+          console.error(e);
+        }
+      }
+    };
+    window.addEventListener("message", handleMessage);
+    return () => window.removeEventListener("message", handleMessage);
+  }, [onMessage, url]);
 
-  const url =
-    `${CANDID_UI_CANISTER_URL}/?id=${canisterId}&tag=${forceUpdate}` + didParam;
   return (
     <CandidPanel isExpanded={isExpanded}>
       <PanelHeader>
@@ -78,7 +128,7 @@ export function CandidUI({ canisterId, candid, setCandidWidth, forceUpdate }) {
           </Button>
         ) : null}
       </PanelHeader>
-      {isExpanded ? <CandidFrame src={url} /> : null}
+      {isExpanded ? <CandidFrame ref={candidFrameRef} src={url} /> : null}
     </CandidPanel>
   );
 }

--- a/src/integrations/editorIntegration.ts
+++ b/src/integrations/editorIntegration.ts
@@ -96,10 +96,9 @@ export async function setupEditorIntegration(
             const response: EditorIntegrationResponse = {
               acknowledge: message.acknowledge,
             };
-            source?.postMessage(
-              `${editorKey}${JSON.stringify(response)}`,
-              origin
-            );
+            source?.postMessage(`${editorKey}${JSON.stringify(response)}`, {
+              targetOrigin: origin,
+            });
           }
         }
       } catch (e) {


### PR DESCRIPTION
Progress toward #122:

The `CandidUI` React component now includes an `onMessage` property which can be used to receive iframe messages.

Preserves cross-origin security and works as expected when simulating `postMessage()` events from the Candid UI iframe using the Chrome dev console. 

Example for sending a message (in the Candid UI codebase):
```ts
const message = {
    "serializable": "json",
};

window.parent?.postMessage(`CandidUI${JSON.stringify(message)}`, '*');
```

Hopefully this is sufficient to unblock progress in #118. 

I'll look into setting up a channel for `did=`, but this will involve a lot more security considerations around unknown origins (whereas for this PR, we always know the expected URL for the Candid UI). 

Is there some API which Candid UI could use to query the Candid data for larger canisters? Or is the goal to override the interface to account for changes in the editor? 