### PR TITLE
Escape "." in localhost regex for external editor integrations

### DIFF
--- a/src/integrations/allowedOrigins.js
+++ b/src/integrations/allowedOrigins.js
@@ -3,7 +3,7 @@
 // Read more: https://developer.mozilla.org/en-US/docs/Web/API/Window/postMessage#security_concerns
 
 const ALLOWED_ORIGINS = [
-  /^https?:\/\/(localhost|127.0.0.1)(:[0-9]+)?$/, // Localhost
+  /^https?:\/\/(localhost|127\.0\.0\.1)(:[0-9]+)?$/, // Localhost
   "https://blocks-editor.github.io", // Blocks (visual Motoko smart contract editor)
 ];
 


### PR DESCRIPTION
Fixes a minor cross-origin vulnerability due to unescaped "." characters in the localhost regex for the external editor integration list. 

Identified when looking into adding similar functionality for dfinity/candid#367.
