### PR TITLE
prune expired child canister

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches: [main]
   pull_request:
+    paths:
+      - 'service/**'
 
 jobs:
   build:

--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,5 @@
 # See https://help.github.com/articles/ignoring-files/ for more about ignoring files.
 
-# dfx
-*.old.did
-
 # dependencies
 /node_modules
 /.pnp
@@ -12,7 +9,7 @@
 /coverage
 
 # production
-/.dfx
+.dfx
 /build
 target/
 
@@ -35,5 +32,3 @@ yarn-error.log*
 /.vscode
 /.history
 
-# Tests
-/service/pool/tests/actor_class/.dfx

--- a/service/pool/Main.mo
+++ b/service/pool/Main.mo
@@ -228,7 +228,7 @@ shared(creator) actor class Self(opt_params : ?Types.InitParams) = this {
         let info = await getExpiredCanisterInfo();
         let result = pool.setChild(caller, info.id);
         if (not result) {
-            throw Error.reject("Actor classes can only spawn up to " # Nat.toText(params.max_num_children) # " children");
+            throw Error.reject("Each canister can only spawn up to " # Nat.toText(params.max_num_children) # " children");
         };
         { canister_id = info.id }
     };

--- a/service/pool/Types.mo
+++ b/service/pool/Types.mo
@@ -190,9 +190,12 @@ module {
         };
 
         public func getChildren(parent: Principal) : List.List<Principal> {
+            let now = Time.now();
             switch(childrens.get parent) {
                 case null List.nil();
-                case (?children) children;
+                case (?children) {
+                         List.filter(children, func (p:Principal):Bool = Option.unwrap(info(p)).timestamp > now - ttl);
+                     }
             }
         };
 

--- a/service/pool/tests/actor_class/test.sh
+++ b/service/pool/tests/actor_class/test.sh
@@ -22,7 +22,7 @@ assert _ == opt "Hey";
 call c1.makeChild(1);
 call c1.makeChild(2);
 fail call c1.makeChild(3);
-assert _ ~= "Actor classes can only spawn up to 3 children";
+assert _ ~= "Each canister can only spawn up to 3 children";
 
 call c1.stopChild(0);
 fail call c1.sayHi(0);


### PR DESCRIPTION
`getChildren` should only return unexpired canisters. The parent canister can get refreshed, then the expired child canisters should not take the quota of `max_num_children`.