### PR TITLE
skip getSubtree for non-root parent

### DIFF
--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -8,6 +8,7 @@ on:
       - '**.ts'
       - '**.js'
       - '**.json'
+      - '**.tsx'
 
 jobs:
   build:

--- a/service/pool/Main.mo
+++ b/service/pool/Main.mo
@@ -164,6 +164,10 @@ shared(creator) actor class Self(opt_params : ?Types.InitParams) = this {
         if (not pool.find(parent)) {
             throw Error.reject "Canister not found";
         };
+        // Do not return subtree for non-root parent to save cost
+        if (not pool.isRoot(parent.id)) {
+            return [];
+        };
         var result = List.nil<(Principal, [Types.CanisterInfo])>();
         var queue = Deque.empty<Principal>();
         queue := Deque.pushBack(queue, parent.id);

--- a/service/pool/Types.mo
+++ b/service/pool/Types.mo
@@ -201,6 +201,8 @@ module {
             }
         };
 
+        public func isRoot(node: Principal) : Bool = Option.isNull(parents.get node);
+
         private func treeSize(node: Principal) : Nat {
             switch (parents.get node) {
                 // found root

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -327,6 +327,9 @@ export function App() {
                   );
                   Object.entries(workplaceState.canisters).forEach(
                     async ([_, info]) => {
+                      if (!info.timestamp || info.isExternal) {
+                        return;
+                      }
                       const subtree = await backend.getSubtree(info);
                       subtree.reverse().forEach(([parentId, children]) => {
                         const parentName = nameMap[parentId];


### PR DESCRIPTION
Frontend calls `getSubtree` for every canister on the list. This fix removes some redundant computation. Also fix a bug in the frontend when the canister is imported.