### PR TITLE
Add code formatter button and key combination

### DIFF
--- a/craco.config.js
+++ b/craco.config.js
@@ -1,3 +1,4 @@
+const { addBeforeLoader, loaderByName } = require('@craco/craco');
 const generateAliases = require("./src/config/generateAliases");
 const path = require("path");
 const webpack = require("webpack");
@@ -50,12 +51,27 @@ const overrideWebpackConfig = ({ webpackConfig }) => {
     new webpack.EnvironmentPlugin(canisterEnv),
   ];
 
+  // Load WASM modules
+  webpackConfig.resolve.extensions.push('.wasm');
+  webpackConfig.module.rules.forEach((rule) => {
+    (rule.oneOf || []).forEach((oneOf) => {
+      if (oneOf.loader && oneOf.loader.indexOf('file-loader') >= 0) {
+        oneOf.exclude.push(/\.wasm$/);
+      }
+    });
+  });
+  addBeforeLoader(webpackConfig, loaderByName('file-loader'), {
+    test: /\.wasm$/,
+    exclude: /node_modules/,
+    loaders: ['wasm-loader'],
+  });
+
   return webpackConfig;
 };
 
 module.exports = {
-  plugins: [{ 
-    plugin: { overrideWebpackConfig } 
+  plugins: [{
+    plugin: { overrideWebpackConfig }
   }, {
     // Fixes a Babel error encountered on Node 16.x / 18.x
     plugin: require("craco-babel-loader"),

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "@types/styled-components": "^5.1.10",
         "lodash.debounce": "^4.0.8",
         "motoko": "^2.0.7",
+        "prettier-plugin-motoko": "^0.1.4",
         "react": "^17.0.2",
         "react-dom": "^17.0.2",
         "react-markdown": "^6.0.2",
@@ -36,8 +37,9 @@
         "craco-babel-loader": "^1.0.3",
         "husky": "^7.0.1",
         "lint-staged": "^11.1.2",
-        "prettier": "^2.3.2",
-        "react-scripts": "4.0.3"
+        "prettier": "^2.7.1",
+        "react-scripts": "4.0.3",
+        "wasm-loader": "^1.3.0"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -12128,6 +12130,15 @@
         "url": "https://tidelift.com/funding/github/npm/loglevel"
       }
     },
+    "node_modules/long": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/long/-/long-3.2.0.tgz",
+      "integrity": "sha512-ZYvPPOMqUwPoDsbJaR10iQJYnMuZhRTvHYl62ErLIEX7RgFlziSBUUvrt3OVfc47QlHHpzPZYP17g3Fv7oeJkg==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
     "node_modules/loose-envify": {
       "version": "1.4.0",
       "license": "MIT",
@@ -14861,14 +14872,25 @@
       }
     },
     "node_modules/prettier": {
-      "version": "2.3.2",
-      "dev": true,
-      "license": "MIT",
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.7.1.tgz",
+      "integrity": "sha512-ujppO+MkdPqoVINuDFDRLClm7D78qbDt0/NR+wp5FqEZOoTNAjPHWj17QRhu7geIHJfcNhRk1XVQmF8Bp3ye+g==",
       "bin": {
         "prettier": "bin-prettier.js"
       },
       "engines": {
         "node": ">=10.13.0"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
+    "node_modules/prettier-plugin-motoko": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/prettier-plugin-motoko/-/prettier-plugin-motoko-0.1.4.tgz",
+      "integrity": "sha512-J0DiRcFqNH1E4LeF7TxseQ06OiIIiv4mRh1cRj8fnYcv7vn3rWBi8k/+ckUDsTckRmIwjI8aPMScqlxv6frzNg==",
+      "peerDependencies": {
+        "prettier": "^2.7"
       }
     },
     "node_modules/pretty-bytes": {
@@ -19060,6 +19082,58 @@
         "loose-envify": "^1.0.0"
       }
     },
+    "node_modules/wasm-dce": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wasm-dce/-/wasm-dce-1.0.2.tgz",
+      "integrity": "sha512-Fq1+nu43ybsjSnBquLrW/cULmKs61qbv9k8ep13QUe0nABBezMoNAA+j6QY66MW0/eoDVDp1rjXDqQ2VKyS/Xg==",
+      "dev": true,
+      "dependencies": {
+        "@babel/core": "^7.0.0-beta.39",
+        "@babel/traverse": "^7.0.0-beta.39",
+        "@babel/types": "^7.0.0-beta.39",
+        "babylon": "^7.0.0-beta.39",
+        "webassembly-interpreter": "0.0.30"
+      }
+    },
+    "node_modules/wasm-dce/node_modules/babylon": {
+      "version": "7.0.0-beta.47",
+      "resolved": "https://registry.npmjs.org/babylon/-/babylon-7.0.0-beta.47.tgz",
+      "integrity": "sha512-+rq2cr4GDhtToEzKFD6KZZMDBXhjFAr9JjPw9pAppZACeEWqNM294j+NdBzkSHYXwzzBmVjZ3nEVJlOhbR2gOQ==",
+      "dev": true,
+      "bin": {
+        "babylon": "bin/babylon.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/wasm-loader": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/wasm-loader/-/wasm-loader-1.3.0.tgz",
+      "integrity": "sha512-R4s75XH+o8qM+WaRrAU9S2rbAMDzob18/S3V8R9ZoFpZkPWLAohWWlzWAp1ybeTkOuuku/X1zJtxiV0pBYxZww==",
+      "dev": true,
+      "dependencies": {
+        "loader-utils": "^1.1.0",
+        "wasm-dce": "^1.0.0"
+      },
+      "peerDependencies": {
+        "wasm-dce": "1.x"
+      }
+    },
+    "node_modules/wasm-loader/node_modules/loader-utils": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.4.0.tgz",
+      "integrity": "sha512-qH0WSMBtn/oHuwjy/NucEgbx5dbxxnxup9s4PVXJUDHZBQY+s0NWA9rJf53RBnQZxfch7euUui7hpoAPvALZdA==",
+      "dev": true,
+      "dependencies": {
+        "big.js": "^5.2.2",
+        "emojis-list": "^3.0.0",
+        "json5": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
     "node_modules/watchpack": {
       "version": "1.7.5",
       "dev": true,
@@ -19192,6 +19266,34 @@
     "node_modules/web-vitals": {
       "version": "1.1.2",
       "license": "Apache-2.0"
+    },
+    "node_modules/webassembly-floating-point-hex-parser": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/webassembly-floating-point-hex-parser/-/webassembly-floating-point-hex-parser-0.1.2.tgz",
+      "integrity": "sha512-TUf1H++8U10+stJbFydnvrpG5Sznz5Rilez/oZlV5zI0C/e4cSxd8rALAJ8VpTvjVWxLmL3SVSJUK6Ap9AoiNg==",
+      "dev": true,
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/webassembly-interpreter": {
+      "version": "0.0.30",
+      "resolved": "https://registry.npmjs.org/webassembly-interpreter/-/webassembly-interpreter-0.0.30.tgz",
+      "integrity": "sha512-+Jdy2piEvz9T5j751mOE8+rBO12p+nNW6Fg4kJZ+zP1oUfsm+151sbAbM8AFxWTURmWCGP+r8Lxwfv3pzN1bCQ==",
+      "dev": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.0.0-beta.36",
+        "long": "^3.2.0",
+        "webassembly-floating-point-hex-parser": "0.1.2"
+      },
+      "bin": {
+        "wasm": "lib/bin/repl.js",
+        "wasm2wast": "lib/bin/wasm2wast.js",
+        "wasmast": "lib/bin/wasmast.js",
+        "wasmdump": "lib/bin/wasmdump.js",
+        "wasmrun": "lib/bin/wasmrun.js",
+        "wastast": "lib/bin/wastast.js"
+      }
     },
     "node_modules/webidl-conversions": {
       "version": "6.1.0",
@@ -28414,6 +28516,12 @@
       "version": "1.7.1",
       "dev": true
     },
+    "long": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/long/-/long-3.2.0.tgz",
+      "integrity": "sha512-ZYvPPOMqUwPoDsbJaR10iQJYnMuZhRTvHYl62ErLIEX7RgFlziSBUUvrt3OVfc47QlHHpzPZYP17g3Fv7oeJkg==",
+      "dev": true
+    },
     "loose-envify": {
       "version": "1.4.0",
       "requires": {
@@ -30293,8 +30401,15 @@
       "dev": true
     },
     "prettier": {
-      "version": "2.3.2",
-      "dev": true
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.7.1.tgz",
+      "integrity": "sha512-ujppO+MkdPqoVINuDFDRLClm7D78qbDt0/NR+wp5FqEZOoTNAjPHWj17QRhu7geIHJfcNhRk1XVQmF8Bp3ye+g=="
+    },
+    "prettier-plugin-motoko": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/prettier-plugin-motoko/-/prettier-plugin-motoko-0.1.4.tgz",
+      "integrity": "sha512-J0DiRcFqNH1E4LeF7TxseQ06OiIIiv4mRh1cRj8fnYcv7vn3rWBi8k/+ckUDsTckRmIwjI8aPMScqlxv6frzNg==",
+      "requires": {}
     },
     "pretty-bytes": {
       "version": "5.6.0",
@@ -33123,6 +33238,50 @@
         "loose-envify": "^1.0.0"
       }
     },
+    "wasm-dce": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wasm-dce/-/wasm-dce-1.0.2.tgz",
+      "integrity": "sha512-Fq1+nu43ybsjSnBquLrW/cULmKs61qbv9k8ep13QUe0nABBezMoNAA+j6QY66MW0/eoDVDp1rjXDqQ2VKyS/Xg==",
+      "dev": true,
+      "requires": {
+        "@babel/core": "^7.0.0-beta.39",
+        "@babel/traverse": "^7.0.0-beta.39",
+        "@babel/types": "^7.0.0-beta.39",
+        "babylon": "^7.0.0-beta.39",
+        "webassembly-interpreter": "0.0.30"
+      },
+      "dependencies": {
+        "babylon": {
+          "version": "7.0.0-beta.47",
+          "resolved": "https://registry.npmjs.org/babylon/-/babylon-7.0.0-beta.47.tgz",
+          "integrity": "sha512-+rq2cr4GDhtToEzKFD6KZZMDBXhjFAr9JjPw9pAppZACeEWqNM294j+NdBzkSHYXwzzBmVjZ3nEVJlOhbR2gOQ==",
+          "dev": true
+        }
+      }
+    },
+    "wasm-loader": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/wasm-loader/-/wasm-loader-1.3.0.tgz",
+      "integrity": "sha512-R4s75XH+o8qM+WaRrAU9S2rbAMDzob18/S3V8R9ZoFpZkPWLAohWWlzWAp1ybeTkOuuku/X1zJtxiV0pBYxZww==",
+      "dev": true,
+      "requires": {
+        "loader-utils": "^1.1.0",
+        "wasm-dce": "^1.0.0"
+      },
+      "dependencies": {
+        "loader-utils": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.4.0.tgz",
+          "integrity": "sha512-qH0WSMBtn/oHuwjy/NucEgbx5dbxxnxup9s4PVXJUDHZBQY+s0NWA9rJf53RBnQZxfch7euUui7hpoAPvALZdA==",
+          "dev": true,
+          "requires": {
+            "big.js": "^5.2.2",
+            "emojis-list": "^3.0.0",
+            "json5": "^1.0.1"
+          }
+        }
+      }
+    },
     "watchpack": {
       "version": "1.7.5",
       "dev": true,
@@ -33217,6 +33376,23 @@
     },
     "web-vitals": {
       "version": "1.1.2"
+    },
+    "webassembly-floating-point-hex-parser": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/webassembly-floating-point-hex-parser/-/webassembly-floating-point-hex-parser-0.1.2.tgz",
+      "integrity": "sha512-TUf1H++8U10+stJbFydnvrpG5Sznz5Rilez/oZlV5zI0C/e4cSxd8rALAJ8VpTvjVWxLmL3SVSJUK6Ap9AoiNg==",
+      "dev": true
+    },
+    "webassembly-interpreter": {
+      "version": "0.0.30",
+      "resolved": "https://registry.npmjs.org/webassembly-interpreter/-/webassembly-interpreter-0.0.30.tgz",
+      "integrity": "sha512-+Jdy2piEvz9T5j751mOE8+rBO12p+nNW6Fg4kJZ+zP1oUfsm+151sbAbM8AFxWTURmWCGP+r8Lxwfv3pzN1bCQ==",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "^7.0.0-beta.36",
+        "long": "^3.2.0",
+        "webassembly-floating-point-hex-parser": "0.1.2"
+      }
     },
     "webidl-conversions": {
       "version": "6.1.0",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "@types/styled-components": "^5.1.10",
     "lodash.debounce": "^4.0.8",
     "motoko": "^2.0.7",
+    "prettier-plugin-motoko": "^0.1.4",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "react-markdown": "^6.0.2",
@@ -31,8 +32,9 @@
     "craco-babel-loader": "^1.0.3",
     "husky": "^7.0.1",
     "lint-staged": "^11.1.2",
-    "prettier": "^2.3.2",
-    "react-scripts": "4.0.3"
+    "prettier": "^2.7.1",
+    "react-scripts": "4.0.3",
+    "wasm-loader": "^1.3.0"
   },
   "scripts": {
     "start": "craco start",

--- a/src/components/Editor.tsx
+++ b/src/components/Editor.tsx
@@ -125,6 +125,19 @@ export function Editor({
   const editorRef = useRef<CodeEditor | undefined>();
   const onEditorMount = (newEditor: CodeEditor) => {
     editorRef.current = newEditor;
+
+    newEditor.onKeyDown((e) => {
+      // Format keyboard shortcut
+      if (
+        (e.ctrlKey || e.metaKey) &&
+        e.shiftKey &&
+        e.browserEvent.key === "f"
+      ) {
+        e.stopPropagation();
+        e.preventDefault();
+        formatClick();
+      }
+    });
   };
   const onEditorChange = (newValue) => {
     debouncedSaveChanges(newValue);

--- a/src/components/Editor.tsx
+++ b/src/components/Editor.tsx
@@ -164,15 +164,17 @@ export function Editor({
       <PanelHeader>
         Editor
         <RightContainer>
-          <Button
-            onClick={formatClick}
-            // disabled={isDeploying}
-            variant="secondary"
-            small
-          >
-            {/* <img src={isDeploying ? iconSpin : iconRabbit} alt="Rabbit icon" /> */}
-            <p>Format</p>
-          </Button>
+          {!!fileName.endsWith(".mo") && (
+            <Button
+              onClick={formatClick}
+              // disabled={isDeploying}
+              variant="secondary"
+              small
+            >
+              {/* <img src={isDeploying ? iconSpin : iconRabbit} alt="Rabbit icon" /> */}
+              <p>Format</p>
+            </Button>
+          )}
           <Button
             onClick={deployClick}
             disabled={isDeploying}

--- a/src/components/Editor.tsx
+++ b/src/components/Editor.tsx
@@ -47,6 +47,7 @@ const MarkdownContainer = styled(EditorContainer)`
 `;
 
 const FormatMessage = styled.div`
+  color: #888;
   display: flex;
   align-content: center;
   text-transform: none;
@@ -121,7 +122,12 @@ export function Editor({
       fileName
     );
   };
-  const saveChanges = async (newValue) => {
+  const saveChanges = async () => {
+    const editor = editorRef.current;
+    if (!editor) {
+      return;
+    }
+    const newValue = editor.getValue();
     dispatch({
       type: "saveFile",
       payload: {
@@ -154,7 +160,7 @@ export function Editor({
     });
   };
   const onEditorChange = (newValue) => {
-    debouncedSaveChanges(newValue);
+    debouncedSaveChanges();
   };
   const formatClick = () => {
     setFormatted(true);

--- a/src/components/Editor.tsx
+++ b/src/components/Editor.tsx
@@ -178,13 +178,7 @@ export function Editor({
         Editor
         <RightContainer>
           {!!fileName.endsWith(".mo") && (
-            <Button
-              onClick={formatClick}
-              // disabled={isDeploying}
-              variant="secondary"
-              small
-            >
-              {/* <img src={isDeploying ? iconSpin : iconRabbit} alt="Rabbit icon" /> */}
+            <Button onClick={formatClick} variant="secondary" small>
               <p>Format</p>
             </Button>
           )}

--- a/src/components/Editor.tsx
+++ b/src/components/Editor.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useContext, useRef } from "react";
+import { useEffect, useContext, useRef, useState } from "react";
 import styled from "styled-components";
 import MonacoEditor, { useMonaco } from "@monaco-editor/react";
 import ReactMarkdown from "react-markdown";
@@ -46,6 +46,18 @@ const MarkdownContainer = styled(EditorContainer)`
   padding: 2rem;
 `;
 
+const FormatMessage = styled.div`
+  display: flex;
+  align-content: center;
+  text-transform: none;
+
+  a {
+    display: inline-block;
+    padding-left: 0.5rem;
+    padding-right: 1rem;
+  }
+`;
+
 function setMarkers(diags, codeModel, monaco, fileName) {
   const markers = [];
   diags.forEach((d) => {
@@ -84,6 +96,8 @@ export function Editor({
 }) {
   const worker = useContext(WorkerContext);
   const dispatch = useContext(WorkplaceDispatchContext);
+
+  const [formatted, setFormatted] = useState(false);
 
   const fileName = state.selectedFile;
   const fileCode = fileName ? state.files[fileName] : "";
@@ -143,6 +157,7 @@ export function Editor({
     debouncedSaveChanges(newValue);
   };
   const formatClick = () => {
+    setFormatted(true);
     editorRef.current?.getAction("editor.action.formatDocument").run();
   };
   const deployClick = async () => {
@@ -178,9 +193,23 @@ export function Editor({
         Editor
         <RightContainer>
           {!!fileName.endsWith(".mo") && (
-            <Button onClick={formatClick} variant="secondary" small>
-              <p>Format</p>
-            </Button>
+            <>
+              {!!formatted && (
+                <FormatMessage>
+                  Formatting is experimental.
+                  <a
+                    href="https://github.com/dfinity/prettier-plugin-motoko/issues"
+                    target="_blank"
+                    rel="noreferrer"
+                  >
+                    Report bugs here.
+                  </a>
+                </FormatMessage>
+              )}
+              <Button onClick={formatClick} variant="secondary" small>
+                <p>Format</p>
+              </Button>
+            </>
           )}
           <Button
             onClick={deployClick}

--- a/src/config/monacoConfig.js
+++ b/src/config/monacoConfig.js
@@ -1,3 +1,27 @@
 import { configure } from "motoko/contrib/monaco";
+import prettier from "prettier";
 
-export const configureMonaco = configure;
+export const configureMonaco = (monaco) => {
+  configure(monaco);
+
+  // Asynchronously load WASM
+  import("prettier-plugin-motoko/lib/environments/web")
+    .then((motokoPlugin) => {
+      monaco.languages.registerDocumentFormattingEditProvider("motoko", {
+        provideDocumentFormattingEdits(model, options, token) {
+          const source = model.getValue();
+          const formatted = prettier.format(source, {
+            plugins: [motokoPlugin],
+            filepath: "*.mo",
+          });
+          return [
+            {
+              range: model.getFullModelRange(),
+              text: formatted,
+            },
+          ];
+        },
+      });
+    })
+    .catch((err) => console.error(err));
+};


### PR DESCRIPTION
Integrates [`prettier-plugin-motoko`](https://github.com/dfinity/prettier-plugin-motoko) with Motoko Playground. 

Code formatting is available through a button in the top-right of the editor as well as the key combinations `Ctrl/Cmd/Option + Shift + F`.

This will be a fantastic way to increase feedback about the formatter, since I'm guessing that a larger number of people will find and report bugs from MP compared to those using the Prettier plugin directly. 
