### PR TITLE
Bump `motoko` and `mo-dev`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "@types/react-dom": "^17.0.0",
         "@types/styled-components": "^5.1.10",
         "lodash.debounce": "^4.0.8",
-        "motoko": "^3.1.0",
+        "motoko": "^3.4.0",
         "prettier-plugin-motoko": "^0.1.5",
         "react": "^17.0.2",
         "react-dom": "^17.0.2",
@@ -40,7 +40,7 @@
         "http-proxy-middleware": "^2.0.6",
         "husky": "^7.0.1",
         "lint-staged": "^11.1.2",
-        "mo-dev": "^0.3.3",
+        "mo-dev": "^0.4.5",
         "prettier": "^2.7.1",
         "react-scripts": "4.0.3",
         "wasm-loader": "^1.3.0"
@@ -5762,6 +5762,18 @@
       "license": "MIT",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/cbor": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/cbor/-/cbor-8.1.0.tgz",
+      "integrity": "sha512-DwGjNW9omn6EwP70aXsn7FQJx5kO12tX0bZkaTjzdVFM6/7nhA4t0EENocKGx6D2Bch9PE2KzCUf5SceBdeijg==",
+      "dev": true,
+      "dependencies": {
+        "nofilter": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=12.19"
       }
     },
     "node_modules/chalk": {
@@ -13301,27 +13313,30 @@
       }
     },
     "node_modules/mo-dev": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/mo-dev/-/mo-dev-0.3.3.tgz",
-      "integrity": "sha512-j8xGfSiJFkm5283xwXnGnWl3ypGdh7dQDIJ/sqQqI1wC8sgV90JqNr90YC+kWrqx//3QRyrPFPXvrbK+330IMw==",
+      "version": "0.4.5",
+      "resolved": "https://registry.npmjs.org/mo-dev/-/mo-dev-0.4.5.tgz",
+      "integrity": "sha512-zyzxGiNE/MkKaniaMLhIcbptU+Sqpc0pVXz4cASZ4pC/6Qzc5XhNsOJwknwMbFBfXebMRX8pAdyJ2Beskqwb3Q==",
       "dev": true,
       "dependencies": {
-        "@dfinity/candid": "^0.15.1",
-        "@dfinity/principal": "^0.15.1",
+        "@dfinity/candid": "0.15.1",
+        "@dfinity/principal": "0.15.1",
         "body-parser": "1.20.1",
+        "bytes": "3.1.2",
+        "cbor": "8.1.0",
         "chokidar": "3.5.3",
         "commander": "9.4.1",
         "cookie-parser": "1.4.6",
         "cors": "2.8.5",
         "debug": "4.3.4",
         "express": "4.18.2",
-        "fast-glob": "^3.2.12",
+        "fast-glob": "3.2.12",
         "http-proxy-middleware": "2.0.6",
         "morgan": "1.10.0",
         "motoko": "3.0.1",
-        "picocolors": "^1.0.0",
+        "picocolors": "1.0.0",
         "swagger-jsdoc": "6.2.5",
-        "swagger-ui-express": "4.5.0"
+        "swagger-ui-express": "4.5.0",
+        "type-is": "1.6.18"
       },
       "bin": {
         "mo-dev": "bin/mo-dev.js"
@@ -13517,9 +13532,9 @@
       }
     },
     "node_modules/motoko": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/motoko/-/motoko-3.1.0.tgz",
-      "integrity": "sha512-5F3KC8qMoqGA20mpAArKU9sr8RdB3hFzRG5udKXztuddJeTgSzf/f/Quorra/Z6ZT8lzNRkosV2ONiQuU+hmXA==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/motoko/-/motoko-3.4.0.tgz",
+      "integrity": "sha512-Qe+3NlSdbmlFpwG7K0t0NRcLPSkyluU0OP3Hki6cW6+VDAghNeL2HndUJoJF1mzqkBqI4DXmOsVeExKpv+85rQ==",
       "dependencies": {
         "cross-fetch": "3.1.5",
         "debug": "4.3.4",
@@ -13854,6 +13869,15 @@
       "version": "1.1.73",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/nofilter": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/nofilter/-/nofilter-3.1.0.tgz",
+      "integrity": "sha512-l2NNj07e9afPnhAhvgVrCD/oy2Ai1yfLpuo3EpiO1jFTsB4sFz6oIfAfSZyQzVpkZQ9xS8ZS5g1jCBgq4Hwo0g==",
+      "dev": true,
+      "engines": {
+        "node": ">=12.19"
+      }
     },
     "node_modules/normalize-package-data": {
       "version": "2.5.0",
@@ -15748,9 +15772,9 @@
       }
     },
     "node_modules/prettier-plugin-motoko": {
-      "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/prettier-plugin-motoko/-/prettier-plugin-motoko-0.1.5.tgz",
-      "integrity": "sha512-4LgR/bLbIG9E4gKrOCMIZ3pyFnRf+SiAIFINCiYDb5ZTApPMjgtbe9xaAXD3M9qUpyY6iy75MfOOPkf6YvsBhw==",
+      "version": "0.1.11",
+      "resolved": "https://registry.npmjs.org/prettier-plugin-motoko/-/prettier-plugin-motoko-0.1.11.tgz",
+      "integrity": "sha512-vtYRIvlM1Qe4q++PoYImrZU8RpWsIRLEPdhlQUh6rW1rMnG40sDnYx4ivmNFbHhVNwPEKo7TnPN9QPLHAmz7cg==",
       "peerDependencies": {
         "prettier": "^2.7"
       }
@@ -25467,6 +25491,15 @@
       "version": "2.3.0",
       "dev": true
     },
+    "cbor": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/cbor/-/cbor-8.1.0.tgz",
+      "integrity": "sha512-DwGjNW9omn6EwP70aXsn7FQJx5kO12tX0bZkaTjzdVFM6/7nhA4t0EENocKGx6D2Bch9PE2KzCUf5SceBdeijg==",
+      "dev": true,
+      "requires": {
+        "nofilter": "^3.1.0"
+      }
+    },
     "chalk": {
       "version": "4.1.1",
       "dev": true,
@@ -30626,27 +30659,30 @@
       }
     },
     "mo-dev": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/mo-dev/-/mo-dev-0.3.3.tgz",
-      "integrity": "sha512-j8xGfSiJFkm5283xwXnGnWl3ypGdh7dQDIJ/sqQqI1wC8sgV90JqNr90YC+kWrqx//3QRyrPFPXvrbK+330IMw==",
+      "version": "0.4.5",
+      "resolved": "https://registry.npmjs.org/mo-dev/-/mo-dev-0.4.5.tgz",
+      "integrity": "sha512-zyzxGiNE/MkKaniaMLhIcbptU+Sqpc0pVXz4cASZ4pC/6Qzc5XhNsOJwknwMbFBfXebMRX8pAdyJ2Beskqwb3Q==",
       "dev": true,
       "requires": {
-        "@dfinity/candid": "^0.15.1",
-        "@dfinity/principal": "^0.15.1",
+        "@dfinity/candid": "0.15.1",
+        "@dfinity/principal": "0.15.1",
         "body-parser": "1.20.1",
+        "bytes": "3.1.2",
+        "cbor": "8.1.0",
         "chokidar": "3.5.3",
         "commander": "9.4.1",
         "cookie-parser": "1.4.6",
         "cors": "2.8.5",
         "debug": "4.3.4",
         "express": "4.18.2",
-        "fast-glob": "^3.2.12",
+        "fast-glob": "3.2.12",
         "http-proxy-middleware": "2.0.6",
         "morgan": "1.10.0",
         "motoko": "3.0.1",
-        "picocolors": "^1.0.0",
+        "picocolors": "1.0.0",
         "swagger-jsdoc": "6.2.5",
-        "swagger-ui-express": "4.5.0"
+        "swagger-ui-express": "4.5.0",
+        "type-is": "1.6.18"
       },
       "dependencies": {
         "binary-extensions": {
@@ -30798,9 +30834,9 @@
       }
     },
     "motoko": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/motoko/-/motoko-3.1.0.tgz",
-      "integrity": "sha512-5F3KC8qMoqGA20mpAArKU9sr8RdB3hFzRG5udKXztuddJeTgSzf/f/Quorra/Z6ZT8lzNRkosV2ONiQuU+hmXA==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/motoko/-/motoko-3.4.0.tgz",
+      "integrity": "sha512-Qe+3NlSdbmlFpwG7K0t0NRcLPSkyluU0OP3Hki6cW6+VDAghNeL2HndUJoJF1mzqkBqI4DXmOsVeExKpv+85rQ==",
       "requires": {
         "cross-fetch": "3.1.5",
         "debug": "4.3.4",
@@ -31056,6 +31092,12 @@
     },
     "node-releases": {
       "version": "1.1.73",
+      "dev": true
+    },
+    "nofilter": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/nofilter/-/nofilter-3.1.0.tgz",
+      "integrity": "sha512-l2NNj07e9afPnhAhvgVrCD/oy2Ai1yfLpuo3EpiO1jFTsB4sFz6oIfAfSZyQzVpkZQ9xS8ZS5g1jCBgq4Hwo0g==",
       "dev": true
     },
     "normalize-package-data": {
@@ -32355,9 +32397,9 @@
       "integrity": "sha512-ujppO+MkdPqoVINuDFDRLClm7D78qbDt0/NR+wp5FqEZOoTNAjPHWj17QRhu7geIHJfcNhRk1XVQmF8Bp3ye+g=="
     },
     "prettier-plugin-motoko": {
-      "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/prettier-plugin-motoko/-/prettier-plugin-motoko-0.1.5.tgz",
-      "integrity": "sha512-4LgR/bLbIG9E4gKrOCMIZ3pyFnRf+SiAIFINCiYDb5ZTApPMjgtbe9xaAXD3M9qUpyY6iy75MfOOPkf6YvsBhw==",
+      "version": "0.1.11",
+      "resolved": "https://registry.npmjs.org/prettier-plugin-motoko/-/prettier-plugin-motoko-0.1.11.tgz",
+      "integrity": "sha512-vtYRIvlM1Qe4q++PoYImrZU8RpWsIRLEPdhlQUh6rW1rMnG40sDnYx4ivmNFbHhVNwPEKo7TnPN9QPLHAmz7cg==",
       "requires": {}
     },
     "pretty-bytes": {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "@types/react-dom": "^17.0.0",
     "@types/styled-components": "^5.1.10",
     "lodash.debounce": "^4.0.8",
-    "motoko": "^3.1.0",
+    "motoko": "^3.4.0",
     "prettier-plugin-motoko": "^0.1.5",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
@@ -34,7 +34,7 @@
     "http-proxy-middleware": "^2.0.6",
     "husky": "^7.0.1",
     "lint-staged": "^11.1.2",
-    "mo-dev": "^0.3.3",
+    "mo-dev": "^0.4.5",
     "prettier": "^2.7.1",
     "react-scripts": "4.0.3",
     "wasm-loader": "^1.3.0"


### PR DESCRIPTION
Includes new code snippets from https://github.com/dfinity/node-motoko/pull/52 and updates `mo-dev` to the latest version.
