### PR TITLE
Markdown error code explanations

### DIFF
--- a/src/components/Editor.tsx
+++ b/src/components/Editor.tsx
@@ -249,6 +249,7 @@ export function Editor({
             scrollBeyondLastLine: false,
             fontSize: 16,
             tabSize: 2,
+            fixedOverflowWidgets: true,
           }}
         />
       </EditorContainer>

--- a/src/components/Editor.tsx
+++ b/src/components/Editor.tsx
@@ -21,9 +21,6 @@ import { compileCandid } from "../build";
 import { didToJs } from "../config/actor";
 import { INTEGRATION_HOOKS } from "../integrations/editorIntegration";
 
-const errorCodes =
-  require("motoko/contrib/generated/errorCodes.json") as Record<string, string>;
-
 const EditorColumn = styled.div`
   display: flex;
   flex-direction: column;
@@ -69,7 +66,6 @@ function setMarkers(diags, codeModel, monaco, fileName) {
       // possible if the error comes from external packages
       return;
     }
-    const explanation = errorCodes[d.code];
     const severity =
       d.severity === 1
         ? monaco.MarkerSeverity.Error
@@ -79,7 +75,7 @@ function setMarkers(diags, codeModel, monaco, fileName) {
       startColumn: d.range.start.character + 1,
       endLineNumber: d.range.end.line + 1,
       endColumn: d.range.end.character + 1,
-      message: explanation ? `${d.message}\n\n${explanation}` : d.message,
+      message: d.message,
       code: d.code,
       severity,
     };

--- a/src/config/monacoConfig.js
+++ b/src/config/monacoConfig.js
@@ -44,7 +44,8 @@ export const configureMonaco = (monaco) => {
             range,
             contents: [
               {
-                value: explanation,
+                // Remove Markdown heading from explanation
+                value: explanation.replace(/^# M[0-9]+\s+/, ""),
               },
             ],
           };

--- a/src/config/monacoConfig.js
+++ b/src/config/monacoConfig.js
@@ -29,34 +29,19 @@ export const configureMonaco = (monaco) => {
     })
     .catch((err) => console.error(err));
 
-  const isInDiagnosticRange = (position, diag) => {
-    if (
-      position.lineNumber < diag.startLineNumber ||
-      position.lineNumber > diag.endLineNumber
-    ) {
-      return false;
-    }
-    if (
-      position.lineNumber === diag.startLineNumber &&
-      position.column < diag.startColumn
-    ) {
-      return false;
-    }
-    if (
-      position.lineNumber === diag.endLineNumber &&
-      position.column >= diag.endColumn
-    ) {
-      return false;
-    }
-    return true;
-  };
-
   monaco.languages.registerHoverProvider("motoko", {
-    provideHover(model, position) {
+    provideHover(_model, position) {
       for (const diag of monaco.editor.getModelMarkers()) {
+        const range = new monaco.Range(
+          diag.startLineNumber,
+          diag.startColumn,
+          diag.endLineNumber,
+          diag.endColumn
+        );
         const explanation = errorCodes[diag.code];
-        if (explanation && isInDiagnosticRange(position, diag)) {
+        if (explanation && range.containsPosition(position)) {
           return {
+            range,
             contents: [
               {
                 value: explanation,

--- a/src/config/monacoConfig.js
+++ b/src/config/monacoConfig.js
@@ -30,7 +30,7 @@ export const configureMonaco = (monaco) => {
     .catch((err) => console.error(err));
 
   monaco.languages.registerHoverProvider("motoko", {
-    provideHover(_model, position) {
+    provideHover(model, position, ...args) {
       for (const diag of monaco.editor.getModelMarkers()) {
         const range = new monaco.Range(
           diag.startLineNumber,
@@ -43,6 +43,9 @@ export const configureMonaco = (monaco) => {
           return {
             range,
             contents: [
+              {
+                value: `\`\`\`text\n${diag.message}\n\`\`\``,
+              },
               {
                 // Remove Markdown heading from explanation
                 value: explanation.replace(/^# M[0-9]+\s+/, ""),


### PR DESCRIPTION
Replaces the plaintext error code explanations with syntax-highlighted Markdown:

<img width="911" alt="image" src="https://github.com/dfinity/motoko-playground/assets/522097/b40724b7-941d-4238-8f60-49e3ab6bd104">

