### PR TITLE
chore: update hash for dfx 0.15.0 frontend canister

### DIFF
--- a/service/wasm-utils/lib.rs
+++ b/service/wasm-utils/lib.rs
@@ -13,7 +13,7 @@ struct Config {
 }
 
 const WHITELISTED_WASMS: [&str; 1] = [ 
-    "651425d92d3796ddae581191452e0e87484eeff4ff6352fe9a59c7e1f97a2310", // dfx 0.14.1 frontend canister
+    "88d1e5795d29debc1ff56fa0696dcb3adfa67f82fe2739d1aa644263838174b9", // dfx 0.15.0 frontend canister
 ];
 
 #[ic_cdk::query]


### PR DESCRIPTION
updates the allowlist to include the latest frontend canister