### PR TITLE
Add stats by origin

### DIFF
--- a/service/pool/Logs.mo
+++ b/service/pool/Logs.mo
@@ -3,6 +3,7 @@ import {compare} "mo:base/Text";
 import {toArray} "mo:base/Iter";
 import {now = timeNow} "mo:base/Time";
 import {toText} "mo:base/Int";
+import {get} "mo:base/Option";
 
 module {
     public type Origin = { origin: Text; tags: [Text] };
@@ -52,7 +53,7 @@ module {
             let now = timeNow() / 1_000_000;
             for ((origin, count) in canisters.entries()) {
                 let name = "canisters_" # origin;
-                let desc = "Number of canisters deployed from " # origin;
+                let desc = "Number of canisters requested from " # origin;
                 result := result # encode_single_value("counter", name, count, desc, now);
             };
             for ((origin, count) in installs.entries()) {
@@ -60,6 +61,17 @@ module {
                 let desc = "Number of Wasm installed from " # origin;
                 result := result # encode_single_value("counter", name, count, desc, now);
             };
+            let profiling = get(tags.get("profiling"), 0);
+            let asset = get(tags.get("asset"), 0);
+            let install = get(tags.get("install"), 0);
+            let reinstall = get(tags.get("reinstall"), 0);
+            let upgrade = get(tags.get("upgrade"), 0);
+            result := result
+            # encode_single_value("counter", "profiling", profiling, "Number of Wasm profiled", now)
+            # encode_single_value("counter", "asset", asset, "Number of asset Wasm canister installed", now)
+            # encode_single_value("counter", "install", install, "Number of Wasm with install mode", now)
+            # encode_single_value("counter", "reinstall", reinstall, "Number of Wasm with reinstall mode", now)
+            # encode_single_value("counter", "upgrade", upgrade, "Number of Wasm with upgrad mode", now);
             result;
         };
     };

--- a/service/pool/Logs.mo
+++ b/service/pool/Logs.mo
@@ -20,15 +20,16 @@ module {
             case (?n) { canisters.put(origin, n + 1) };
             }
         };
-        public func addInstall(origin: Text) {
+        public func addInstall(origin: Text, referrer: ?Text) {
+            // TODO: keep track of `referrer`
             switch (installs.get(origin)) {
             case null { installs.put(origin, 1) };
             case (?n) { installs.put(origin, n + 1) };
             }
         };
         public func dump() : ([(Text, Nat)], [(Text, Nat)]) {
-            (canisters.entries() |> toArray<(Text, Nat)>(_),
-             installs.entries() |> toArray<(Text, Nat)>(_))
+            (toArray<(Text, Nat)>(canisters.entries()),
+             toArray<(Text, Nat)>(installs.entries()))
         };
         public func metrics() : Text {
             var result = "";

--- a/service/pool/Main.mo
+++ b/service/pool/Main.mo
@@ -335,7 +335,7 @@ shared (creator) actor class Self(opt_params : ?Types.InitParams) = this {
         switch (sanitizeInputs(caller, canister_id)) {
             case (#ok info) {
                 let args = { arg; wasm_module; mode; canister_id };
-                let config = { profiling = pool.profiling caller; is_whitelisted = false; origin = "spawn" };
+                let config = { profiling = pool.profiling caller; is_whitelisted = false; origin = "spawned" };
                 ignore await installCode(info, args, config); // inherit the profiling of the parent
             };
             case (#err makeMsg) throw Error.reject(makeMsg "install_code");

--- a/service/pool/Main.mo
+++ b/service/pool/Main.mo
@@ -135,7 +135,7 @@ shared (creator) actor class Self(opt_params : ?Types.InitParams) = this {
         await getExpiredCanisterInfo(origin);
     };
 
-    type InstallConfig = { profiling: Bool; is_whitelisted: Bool; origin: Text };
+    type InstallConfig = { profiling: Bool; is_whitelisted: Bool; origin: Text; referrer: ?Text };
     public shared ({ caller }) func installCode(info : Types.CanisterInfo, args : Types.InstallArgs, install_config : InstallConfig) : async Types.CanisterInfo {
         if (install_config.origin == "") {
             throw Error.reject "Please specify an origin";
@@ -169,7 +169,7 @@ shared (creator) actor class Self(opt_params : ?Types.InitParams) = this {
             };
             await IC.install_code newArgs;
             stats := Logs.updateStats(stats, #install);
-            statsByOrigin.addInstall(install_config.origin);
+            statsByOrigin.addInstall(install_config.origin, install_config.referrer);
             switch (pool.refresh(info, install_config.profiling)) {
                 case (?newInfo) {
                      updateTimer(newInfo);
@@ -335,7 +335,7 @@ shared (creator) actor class Self(opt_params : ?Types.InitParams) = this {
         switch (sanitizeInputs(caller, canister_id)) {
             case (#ok info) {
                 let args = { arg; wasm_module; mode; canister_id };
-                let config = { profiling = pool.profiling caller; is_whitelisted = false; origin = "spawned" };
+                let config = { profiling = pool.profiling caller; is_whitelisted = false; origin = "spawned"; referrer = null };
                 ignore await installCode(info, args, config); // inherit the profiling of the parent
             };
             case (#err makeMsg) throw Error.reject(makeMsg "install_code");

--- a/service/pool/Main.mo
+++ b/service/pool/Main.mo
@@ -23,6 +23,7 @@ shared (creator) actor class Self(opt_params : ?Types.InitParams) = this {
     let params = Option.get(opt_params, Types.defaultParams);
     var pool = Types.CanisterPool(params.max_num_canisters, params.canister_time_to_live, params.max_family_tree_size);
     let nonceCache = PoW.NonceCache(params.nonce_time_to_live);
+    var statsByOrigin = Logs.StatsByOrigin();
 
     stable let controller = creator.caller;
     stable var stats = Logs.defaultStats;
@@ -31,6 +32,7 @@ shared (creator) actor class Self(opt_params : ?Types.InitParams) = this {
     stable var stableChildren : [(Principal, [Principal])] = [];
     stable var stableTimers : [Types.CanisterInfo] = [];
     stable var previousParam : ?Types.InitParams = null;
+    stable var stableStatsByOrigin : Logs.SharedStatsByOrigin = (#leaf, #leaf);
 
     system func preupgrade() {
         let (tree, metadata, children, timers) = pool.share();
@@ -39,6 +41,7 @@ shared (creator) actor class Self(opt_params : ?Types.InitParams) = this {
         stableChildren := children;
         stableTimers := timers;
         previousParam := ?params;
+        stableStatsByOrigin := statsByOrigin.share();
     };
 
     system func postupgrade() {
@@ -50,15 +53,17 @@ shared (creator) actor class Self(opt_params : ?Types.InitParams) = this {
         pool.unshare(stablePool, stableMetadata, stableChildren);
         for (info in stableTimers.vals()) {
             updateTimer(info);
-        }
+        };
+        statsByOrigin.unshare(stableStatsByOrigin);
     };
 
     public query func getInitParams() : async Types.InitParams {
         params;
     };
 
-    public query func getStats() : async Logs.Stats {
-        stats;
+    public query func getStats() : async (Logs.Stats, [(Text, Nat)], [(Text, Nat)]) {
+        let (canister, install) = statsByOrigin.dump();
+        (stats, canister, install);
     };
 
     public query func balance() : async Nat {
@@ -70,7 +75,7 @@ shared (creator) actor class Self(opt_params : ?Types.InitParams) = this {
         ignore Cycles.accept amount;
     };
 
-    private func getExpiredCanisterInfo() : async Types.CanisterInfo {
+    private func getExpiredCanisterInfo(origin : Text) : async Types.CanisterInfo {
         switch (pool.getExpiredCanisterId()) {
             case (#newId) {
                 Cycles.add(params.cycles_per_canister);
@@ -79,6 +84,7 @@ shared (creator) actor class Self(opt_params : ?Types.InitParams) = this {
                 let info = { id = cid.canister_id; timestamp = now };
                 pool.add info;
                 stats := Logs.updateStats(stats, #getId(params.cycles_per_canister));
+                statsByOrigin.addCanister(origin);
                 info;
             };
             case (#reuse info) {
@@ -101,6 +107,7 @@ shared (creator) actor class Self(opt_params : ?Types.InitParams) = this {
                     case _ {};
                 };
                 stats := Logs.updateStats(stats, #getId topUpCycles);
+                statsByOrigin.addCanister(origin);
                 info;
             };
             case (#outOfCapacity time) {
@@ -111,7 +118,10 @@ shared (creator) actor class Self(opt_params : ?Types.InitParams) = this {
         };
     };
 
-    public shared ({ caller }) func getCanisterId(nonce : PoW.Nonce) : async Types.CanisterInfo {
+    public shared ({ caller }) func getCanisterId(nonce : PoW.Nonce, origin : Text) : async Types.CanisterInfo {
+        if (origin == "") {
+            throw Error.reject "Please specify an origin";
+        };
         if (caller != controller and not nonceCache.checkProofOfWork(nonce)) {
             stats := Logs.updateStats(stats, #mismatch);
             throw Error.reject "Proof of work check failed";
@@ -122,10 +132,14 @@ shared (creator) actor class Self(opt_params : ?Types.InitParams) = this {
             throw Error.reject "Nonce already used";
         };
         nonceCache.add nonce;
-        await getExpiredCanisterInfo();
+        await getExpiredCanisterInfo(origin);
     };
 
-    public shared ({ caller }) func installCode(info : Types.CanisterInfo, args : Types.InstallArgs, profiling : Bool, is_whitelisted : Bool) : async Types.CanisterInfo {
+    type InstallConfig = { profiling: Bool; is_whitelisted: Bool; origin: Text };
+    public shared ({ caller }) func installCode(info : Types.CanisterInfo, args : Types.InstallArgs, install_config : InstallConfig) : async Types.CanisterInfo {
+        if (install_config.origin == "") {
+            throw Error.reject "Please specify an origin";
+        };
         if (info.timestamp == 0) {
             stats := Logs.updateStats(stats, #mismatch);
             throw Error.reject "Cannot install removed canister";
@@ -135,14 +149,14 @@ shared (creator) actor class Self(opt_params : ?Types.InitParams) = this {
             throw Error.reject "Cannot find canister";
         } else {
             let config = {
-                profiling;
+                profiling = install_config.profiling;
                 remove_cycles_add = true;
                 limit_stable_memory_page = ?(16384 : Nat32); // Limit to 1G of stable memory
                 backend_canister_id = ?Principal.fromActor(this);
             };
-            let wasm = if (caller == controller and is_whitelisted) {
+            let wasm = if (caller == controller and install_config.is_whitelisted) {
                 args.wasm_module;
-            } else if (is_whitelisted) {
+            } else if (install_config.is_whitelisted) {
                 await Wasm.is_whitelisted(args.wasm_module);
             } else {
                 await Wasm.transform(args.wasm_module, config);
@@ -155,7 +169,8 @@ shared (creator) actor class Self(opt_params : ?Types.InitParams) = this {
             };
             await IC.install_code newArgs;
             stats := Logs.updateStats(stats, #install);
-            switch (pool.refresh(info, profiling)) {
+            statsByOrigin.addInstall(install_config.origin);
+            switch (pool.refresh(info, install_config.profiling)) {
                 case (?newInfo) {
                      updateTimer(newInfo);
                      newInfo;
@@ -241,12 +256,13 @@ shared (creator) actor class Self(opt_params : ?Types.InitParams) = this {
             throw Error.reject "Only called by controller";
         };
         stats := Logs.defaultStats;
+        statsByOrigin := Logs.StatsByOrigin();
     };
 
     // Metrics
     public query func http_request(req : Metrics.HttpRequest) : async Metrics.HttpResponse {
         if (req.url == "/metrics") {
-            let body = Metrics.metrics stats;
+            let body = Metrics.metrics(stats, statsByOrigin);
             {
                 status_code = 200;
                 headers = [("Content-Type", "text/plain; version=0.0.4"), ("Content-Length", Nat.toText(body.size()))];
@@ -294,7 +310,7 @@ shared (creator) actor class Self(opt_params : ?Types.InitParams) = this {
         if (not pool.findId caller) {
             throw Error.reject "Only a canister managed by the Motoko Playground can call create_canister";
         };
-        let info = await getExpiredCanisterInfo();
+        let info = await getExpiredCanisterInfo("spawned");
         let result = pool.setChild(caller, info.id);
         if (not result) {
             throw Error.reject("In the Motoko Playground, each top level canister can only spawn " # Nat.toText(params.max_family_tree_size) # " descendants including itself");
@@ -319,7 +335,8 @@ shared (creator) actor class Self(opt_params : ?Types.InitParams) = this {
         switch (sanitizeInputs(caller, canister_id)) {
             case (#ok info) {
                 let args = { arg; wasm_module; mode; canister_id };
-                ignore await installCode(info, args, pool.profiling caller, false); // inherit the profiling of the parent
+                let config = { profiling = pool.profiling caller; is_whitelisted = false; origin = "spawn" };
+                ignore await installCode(info, args, config); // inherit the profiling of the parent
             };
             case (#err makeMsg) throw Error.reject(makeMsg "install_code");
         };

--- a/service/pool/Metrics.mo
+++ b/service/pool/Metrics.mo
@@ -1,6 +1,5 @@
 import Text "mo:base/Text";
 import Time "mo:base/Time";
-import Int "mo:base/Int";
 import Logs "./Logs";
 
 module {
@@ -15,12 +14,8 @@ module {
         headers: [(Text, Text)];
         body: Blob;
     };
-    func encode_single_value(kind: Text, name: Text, number: Int, desc: Text, time: Int) : Text {
-        "# HELP " # name # " " # desc # "\n" #
-        "# TYPE " # name # " " # kind # "\n" #
-        name # " " # Int.toText(number) # " " # Int.toText(time) # "\n"
-    };
-    public func metrics(stats: Logs.Stats) : Blob {
+    let encode_single_value = Logs.encode_single_value;
+    public func metrics(stats: Logs.Stats, origin: Logs.StatsByOrigin) : Blob {
         let now = Time.now() / 1_000_000;
         var result = "";
         result := result # encode_single_value("counter", "canister_count", stats.num_of_canisters, "Number of canisters deployed", now);
@@ -29,6 +24,7 @@ module {
         result := result # encode_single_value("counter", "out_of_capacity", stats.error_out_of_capacity, "Number of out of capacity requests", now);
         result := result # encode_single_value("counter", "total_wait_time", stats.error_total_wait_time, "Number of seconds waiting for out of capacity requests", now);
         result := result # encode_single_value("counter", "mismatch", stats.error_mismatch, "Number of mismatch requests including wrong nounce and timestamp", now);
+        result := result # origin.metrics();
         Text.encodeUtf8(result)
     };
 }

--- a/service/pool/tests/actor_class/test.sh
+++ b/service/pool/tests/actor_class/test.sh
@@ -7,9 +7,9 @@ let deleter = file(".dfx/local/canisters/Deleter/Deleter.wasm");
 let S = install(wasm, null, opt 100_000_000_000_000);
 
 let nonce = record { timestamp = 1 : int; nonce = 1 : nat };
-let c1 = call S.getCanisterId(nonce);
+let c1 = call S.getCanisterId(nonce, "test");
 let args = record { arg = blob ""; wasm_module = parent; mode = variant { install }; canister_id = c1.id };
-call S.installCode(c1, args, false, false);
+call S.installCode(c1, args, record { profiling = false; is_whitelisted = false; origin = "test" });
 
 let c1 = c1.id;
 
@@ -48,26 +48,26 @@ let init = opt record {
 let S = install(wasm, init, opt 100_000_000_000_000);
 
 let nonce = record { timestamp = 1 : int; nonce = 1 : nat };
-let c1 = call S.getCanisterId(nonce);
+let c1 = call S.getCanisterId(nonce, "test");
 let args = record { arg = blob ""; wasm_module = parent; mode = variant { install }; canister_id = c1.id };
-call S.installCode(c1, args, false, false);
+call S.installCode(c1, args, record { profiling = false; is_whitelisted = false; origin = "test" });
 let c1 = c1.id;
 
 fail call c1.makeChild(0);
-call S.getCanisterId(nonce);
-call S.getCanisterId(nonce);
+call S.getCanisterId(nonce, "test");
+call S.getCanisterId(nonce, "test");
 
 // Security check
 let S = install(wasm, null, opt 100_000_000_000_000);
 
 let nonce = record { timestamp = 1 : int; nonce = 1 : nat };
-let c1 = call S.getCanisterId(nonce);
+let c1 = call S.getCanisterId(nonce, "test");
 let args = record { arg = blob ""; wasm_module = parent; mode = variant { install }; canister_id = c1.id };
-call S.installCode(c1, args, false, false);
+call S.installCode(c1, args, record { profiling = false; is_whitelisted = false; origin = "test" });
 
-let c2 = call S.getCanisterId(nonce);
+let c2 = call S.getCanisterId(nonce, "test");
 let args = record { arg = blob ""; wasm_module = deleter; mode = variant { install }; canister_id = c2.id };
-call S.installCode(c2, args, false, false);
+call S.installCode(c2, args, record { profiling = false; is_whitelisted = false; origin = "test" });
 
 let c1 = c1.id;
 let c2 = c2.id;

--- a/service/pool/tests/actor_class/test.sh
+++ b/service/pool/tests/actor_class/test.sh
@@ -7,9 +7,10 @@ let deleter = file(".dfx/local/canisters/Deleter/Deleter.wasm");
 let S = install(wasm, null, opt 100_000_000_000_000);
 
 let nonce = record { timestamp = 1 : int; nonce = 1 : nat };
-let c1 = call S.getCanisterId(nonce, "test");
+let origin = record { origin = "test"; tags = vec {} };
+let c1 = call S.getCanisterId(nonce, origin);
 let args = record { arg = blob ""; wasm_module = parent; mode = variant { install }; canister_id = c1.id };
-call S.installCode(c1, args, record { profiling = false; is_whitelisted = false; origin = "test" });
+call S.installCode(c1, args, record { profiling = false; is_whitelisted = false; origin = origin });
 
 let c1 = c1.id;
 
@@ -48,26 +49,26 @@ let init = opt record {
 let S = install(wasm, init, opt 100_000_000_000_000);
 
 let nonce = record { timestamp = 1 : int; nonce = 1 : nat };
-let c1 = call S.getCanisterId(nonce, "test");
+let c1 = call S.getCanisterId(nonce, origin);
 let args = record { arg = blob ""; wasm_module = parent; mode = variant { install }; canister_id = c1.id };
-call S.installCode(c1, args, record { profiling = false; is_whitelisted = false; origin = "test" });
+call S.installCode(c1, args, record { profiling = false; is_whitelisted = false; origin = origin });
 let c1 = c1.id;
 
 fail call c1.makeChild(0);
-call S.getCanisterId(nonce, "test");
-call S.getCanisterId(nonce, "test");
+call S.getCanisterId(nonce, origin);
+call S.getCanisterId(nonce, origin);
 
 // Security check
 let S = install(wasm, null, opt 100_000_000_000_000);
 
 let nonce = record { timestamp = 1 : int; nonce = 1 : nat };
-let c1 = call S.getCanisterId(nonce, "test");
+let c1 = call S.getCanisterId(nonce, origin);
 let args = record { arg = blob ""; wasm_module = parent; mode = variant { install }; canister_id = c1.id };
-call S.installCode(c1, args, record { profiling = false; is_whitelisted = false; origin = "test" });
+call S.installCode(c1, args, record { profiling = false; is_whitelisted = false; origin = origin });
 
-let c2 = call S.getCanisterId(nonce, "test");
+let c2 = call S.getCanisterId(nonce, origin);
 let args = record { arg = blob ""; wasm_module = deleter; mode = variant { install }; canister_id = c2.id };
-call S.installCode(c2, args, record { profiling = false; is_whitelisted = false; origin = "test" });
+call S.installCode(c2, args, record { profiling = false; is_whitelisted = false; origin = origin });
 
 let c1 = c1.id;
 let c2 = c2.id;

--- a/service/pool/tests/canisterPool.test.sh
+++ b/service/pool/tests/canisterPool.test.sh
@@ -14,7 +14,7 @@ let init = opt record {
 let S = install(wasm, init, null);
 let nonce = record { timestamp = 1 : int; nonce = 1 : nat };
 let CID = call S.getCanisterId(nonce);
-call S.installCode(CID, record { arg = blob ""; wasm_module = empty_wasm; mode = variant { install }; canister_id = CID.id }, false, false);
+call S.installCode(CID, record { arg = blob ""; wasm_module = empty_wasm; mode = variant { install }; canister_id = CID.id }, record { profiling = false; is_whitelisted = false; origin = "test" });
 metadata(CID.id, "module_hash");
 
 // Immediately expire
@@ -27,13 +27,13 @@ let init = opt record {
 };
 let S = install(wasm, init, null);
 
-let c1 = call S.getCanisterId(nonce);
+let c1 = call S.getCanisterId(nonce, "test");
 c1;
-let c2 = call S.getCanisterId(nonce);
+let c2 = call S.getCanisterId(nonce, "test");
 c2;
-let c3 = call S.getCanisterId(nonce);
+let c3 = call S.getCanisterId(nonce, "test");
 c3;
-let c4 = call S.getCanisterId(nonce);
+let c4 = call S.getCanisterId(nonce, "test");
 c4;
 assert c1.id != c2.id;
 assert c1.id == c3.id;
@@ -48,14 +48,14 @@ let init = opt record {
   max_family_tree_size = 5 : nat;
 };
 reinstall(S, wasm, init);
-let c3 = call S.getCanisterId(nonce);
+let c3 = call S.getCanisterId(nonce, "test");
 c3;
-let c4 = call S.getCanisterId(nonce);
+let c4 = call S.getCanisterId(nonce, "test");
 c4;
-fail call S.getCanisterId(nonce);
+fail call S.getCanisterId(nonce, "test");
 assert _ ~= "No available canister id";
 call S.removeCode(c4);
-call S.getCanisterId(nonce);
+call S.getCanisterId(nonce, "test");
 assert _.id == c4.id;
 assert _.timestamp != c4.timestamp;
 
@@ -68,7 +68,7 @@ let init = opt record {
   max_family_tree_size = 5 : nat;
 };
 let S = install(wasm, init, opt 100_000_000_000);
-fail call S.getCanisterId(nonce);
+fail call S.getCanisterId(nonce, "test");
 assert _ ~= "105_000_000_000 cycles";
 call ic.provisional_top_up_canister(
   record {
@@ -76,7 +76,7 @@ call ic.provisional_top_up_canister(
     amount = 100_000_000_000_000;
   },
 );
-call S.getCanisterId(nonce);
+call S.getCanisterId(nonce, "test");
 
 // Enough time has passed that the timer has removed the canister code
 fail metadata(CID.id, "module_hash");

--- a/service/pool/tests/canisterPool.test.sh
+++ b/service/pool/tests/canisterPool.test.sh
@@ -13,7 +13,7 @@ let init = opt record {
 };
 let S = install(wasm, init, null);
 let nonce = record { timestamp = 1 : int; nonce = 1 : nat };
-let CID = call S.getCanisterId(nonce);
+let CID = call S.getCanisterId(nonce, "test");
 call S.installCode(CID, record { arg = blob ""; wasm_module = empty_wasm; mode = variant { install }; canister_id = CID.id }, record { profiling = false; is_whitelisted = false; origin = "test" });
 metadata(CID.id, "module_hash");
 

--- a/service/pool/tests/nonce.test.sh
+++ b/service/pool/tests/nonce.test.sh
@@ -13,11 +13,11 @@ let init = opt record {
 };
 let S = install(wasm, init, null);
 
-call S.getCanisterId(record { timestamp = 4780472194_000_000_000; nonce = 1 });
-fail call S.getCanisterId(record { timestamp = 4780472194_000_000_000; nonce = 1 });
+call S.getCanisterId(record { timestamp = 4780472194_000_000_000; nonce = 1 }, "test");
+fail call S.getCanisterId(record { timestamp = 4780472194_000_000_000; nonce = 1 }, "test");
 assert _ ~= "Nonce already used";
-call S.getCanisterId(record { timestamp = 4780472194_000_000_001; nonce = 1 });
+call S.getCanisterId(record { timestamp = 4780472194_000_000_001; nonce = 1 }, "test");
 
 identity bob;
-fail call S.getCanisterId(record { timestamp = 4780472194_000_000_002; nonce = 1 });
+fail call S.getCanisterId(record { timestamp = 4780472194_000_000_002; nonce = 1 }, "test");
 assert _ ~= "Proof of work check failed";

--- a/service/pool/tests/nonce.test.sh
+++ b/service/pool/tests/nonce.test.sh
@@ -2,6 +2,7 @@
 load "prelude.sh";
 
 let wasm = file("../../../.dfx/local/canisters/backend/backend.wasm");
+let origin = record { origin = "test"; tags = vec {} };
 
 identity alice;
 let init = opt record {
@@ -13,11 +14,11 @@ let init = opt record {
 };
 let S = install(wasm, init, null);
 
-call S.getCanisterId(record { timestamp = 4780472194_000_000_000; nonce = 1 }, "test");
-fail call S.getCanisterId(record { timestamp = 4780472194_000_000_000; nonce = 1 }, "test");
+call S.getCanisterId(record { timestamp = 4780472194_000_000_000; nonce = 1 }, origin);
+fail call S.getCanisterId(record { timestamp = 4780472194_000_000_000; nonce = 1 }, origin);
 assert _ ~= "Nonce already used";
-call S.getCanisterId(record { timestamp = 4780472194_000_000_001; nonce = 1 }, "test");
+call S.getCanisterId(record { timestamp = 4780472194_000_000_001; nonce = 1 }, origin);
 
 identity bob;
-fail call S.getCanisterId(record { timestamp = 4780472194_000_000_002; nonce = 1 }, "test");
+fail call S.getCanisterId(record { timestamp = 4780472194_000_000_002; nonce = 1 }, origin);
 assert _ ~= "Proof of work check failed";

--- a/service/pool/tests/upgrade.test.sh
+++ b/service/pool/tests/upgrade.test.sh
@@ -13,15 +13,15 @@ let init = opt record {
 let S = install(wasm, init, null);
 
 let nonce = record { timestamp = 1 : int; nonce = 1 : nat };
-let c1 = call S.getCanisterId(nonce);
+let c1 = call S.getCanisterId(nonce, "test");
 c1;
-let c2 = call S.getCanisterId(nonce);
+let c2 = call S.getCanisterId(nonce, "test");
 c2;
 
 upgrade(S, wasm, init);
-let c3 = call S.getCanisterId(nonce);
+let c3 = call S.getCanisterId(nonce, "test");
 c3;
-let c4 = call S.getCanisterId(nonce);
+let c4 = call S.getCanisterId(nonce, "test");
 c4;
 assert c1.id != c2.id;
 assert c1.id == c3.id;
@@ -35,12 +35,16 @@ let init = opt record {
   canister_time_to_live = 3600_000_000_000 : nat;
   max_family_tree_size = 5 : nat;
 };
+let stats = call S.getStats();
 upgrade(S, wasm, init);
-let c5 = call S.getCanisterId(nonce);
+// stats are preserved after upgrade
+call S.getStats();
+assert _ == stats;
+let c5 = call S.getCanisterId(nonce, "test");
 c5;
 assert c5.id != c1.id;
 assert c5.id != c2.id;
-fail call S.getCanisterId(nonce);
+fail call S.getCanisterId(nonce, "test");
 assert _ ~= "No available canister id";
 
 // Cannot reduce pool
@@ -54,5 +58,5 @@ let init = opt record {
 fail upgrade(S, wasm, init);
 assert _ ~= "Cannot reduce canisterPool for upgrade";
 // still old canister, new TTL does not apply
-fail call S.getCanisterId(nonce);
+fail call S.getCanisterId(nonce, "test");
 assert _ ~= "No available canister id";

--- a/service/pool/tests/upgrade.test.sh
+++ b/service/pool/tests/upgrade.test.sh
@@ -2,6 +2,7 @@
 load "prelude.sh";
 
 let wasm = file("../../../.dfx/local/canisters/backend/backend.wasm");
+let origin = record { origin = "test"; tags = vec {"tag"} };
 
 let init = opt record {
   cycles_per_canister = 105_000_000_000 : nat;
@@ -13,15 +14,15 @@ let init = opt record {
 let S = install(wasm, init, null);
 
 let nonce = record { timestamp = 1 : int; nonce = 1 : nat };
-let c1 = call S.getCanisterId(nonce, "test");
+let c1 = call S.getCanisterId(nonce, origin);
 c1;
-let c2 = call S.getCanisterId(nonce, "test");
+let c2 = call S.getCanisterId(nonce, origin);
 c2;
 
 upgrade(S, wasm, init);
-let c3 = call S.getCanisterId(nonce, "test");
+let c3 = call S.getCanisterId(nonce, origin);
 c3;
-let c4 = call S.getCanisterId(nonce, "test");
+let c4 = call S.getCanisterId(nonce, origin);
 c4;
 assert c1.id != c2.id;
 assert c1.id == c3.id;
@@ -40,11 +41,11 @@ upgrade(S, wasm, init);
 // stats are preserved after upgrade
 call S.getStats();
 assert _ == stats;
-let c5 = call S.getCanisterId(nonce, "test");
+let c5 = call S.getCanisterId(nonce, origin);
 c5;
 assert c5.id != c1.id;
 assert c5.id != c2.id;
-fail call S.getCanisterId(nonce, "test");
+fail call S.getCanisterId(nonce, origin);
 assert _ ~= "No available canister id";
 
 // Cannot reduce pool
@@ -58,5 +59,5 @@ let init = opt record {
 fail upgrade(S, wasm, init);
 assert _ ~= "Cannot reduce canisterPool for upgrade";
 // still old canister, new TTL does not apply
-fail call S.getCanisterId(nonce, "test");
+fail call S.getCanisterId(nonce, origin);
 assert _ ~= "No available canister id";

--- a/service/wasm-utils/Cargo.lock
+++ b/service/wasm-utils/Cargo.lock
@@ -60,9 +60,9 @@ checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
 name = "candid"
-version = "0.9.5"
+version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "762aa04e3a889d47a1773b74ee3b13438a9bc895954fff79ebf7f308c3744a6c"
+checksum = "88f6eec0ae850e006ef0fe306f362884d370624094ec55a6a26de18b251774be"
 dependencies = [
  "anyhow",
  "binread",
@@ -87,14 +87,14 @@ dependencies = [
 
 [[package]]
 name = "candid_derive"
-version = "0.6.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "810b3bd60244f282090652ffc7c30a9d23892e72dfe443e46ee55569044f7dd5"
+checksum = "158403ea38fab5904ae47a5d67eb7047650a91681407f5ccbcbcabc4f4ffb489"
 dependencies = [
  "lazy_static",
  "proc-macro2",
  "quote",
- "syn 2.0.29",
+ "syn 2.0.31",
 ]
 
 [[package]]
@@ -329,9 +329,9 @@ checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
 
 [[package]]
 name = "memchr"
-version = "2.6.2"
+version = "2.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5486aed0026218e61b8a01d5fbd5a0a134649abb71a0e53b7bc088529dced86e"
+checksum = "8f232d6ef707e1956a43342693d2a31e72989554d58299d7a88738cc95b0d35c"
 
 [[package]]
 name = "num-bigint"
@@ -382,7 +382,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.29",
+ "syn 2.0.31",
 ]
 
 [[package]]
@@ -483,7 +483,7 @@ checksum = "4eca7ac642d82aa35b60049a6eccb4be6be75e599bd2e9adb5f875a737654af2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.29",
+ "syn 2.0.31",
 ]
 
 [[package]]
@@ -540,9 +540,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.29"
+version = "2.0.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c324c494eba9d92503e6f1ef2e6df781e78f6a7705a0202d9801b198807d518a"
+checksum = "718fa2415bcb8d8bd775917a1bf12a7931b6dfa890753378538118181e0cb398"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -560,22 +560,22 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.47"
+version = "1.0.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97a802ec30afc17eee47b2855fc72e0c4cd62be9b4efe6591edde0ec5bd68d8f"
+checksum = "9d6d7a740b8a666a7e828dd00da9c0dc290dff53154ea77ac109281de90589b7"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.47"
+version = "1.0.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6bb623b56e39ab7dcd4b1b98bb6c8f8d907ed255b18de254088016b27a8ee19b"
+checksum = "49922ecae66cc8a249b77e68d1d0623c1b2c514f0060c27cdc68bd62a1219d35"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.29",
+ "syn 2.0.31",
 ]
 
 [[package]]

--- a/service/wasm-utils/Cargo.toml
+++ b/service/wasm-utils/Cargo.toml
@@ -12,7 +12,7 @@ hex = "0.4.3"
 ic-cdk = "0.10.0"
 serde = "1.0"
 serde_bytes = "0.11"
-candid = "0.9.1"
+candid = "0.9.6"
 ic-wasm = { version = "0.4.0", default-features = false }
 sha2 = "0.10.6"
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -82,7 +82,7 @@ async function fetchFromUrlParams(
       const { origin, files } = result;
       await dispatch({
         type: "setOrigin",
-        payload: { origin: `playground:post:${origin}` },
+        payload: { origin: `playground:post:${origin}`, tags: [] },
       });
       return files;
     }
@@ -95,7 +95,7 @@ async function fetchFromUrlParams(
     };
     await dispatch({
       type: "setOrigin",
-      payload: { origin: `playground:git:${git}` },
+      payload: { origin: "playground:git", tags: [`git:${git}`] },
     });
     return await worker.fetchGithub(repo);
   }
@@ -147,7 +147,7 @@ async function fetchFromUrlParams(
       }
       await dispatch({
         type: "setOrigin",
-        payload: { origin: `playground:tag:${tag}` },
+        payload: { origin: "playground:tag", tags: [`tag:${tag}`] },
       });
       return files;
     }

--- a/src/build.ts
+++ b/src/build.ts
@@ -109,7 +109,8 @@ export async function deploy(
   mode: string,
   wasm: Uint8Array,
   profiling: boolean,
-  logger: ILoggingStore
+  logger: ILoggingStore,
+  origin: string
 ): Promise<CanisterInfo | undefined> {
   try {
     logger.log(`Deploying code...`);
@@ -126,7 +127,8 @@ export async function deploy(
         args,
         "install",
         profiling,
-        logger
+        logger,
+        origin
       );
     } else {
       if (mode !== "reinstall" && mode !== "upgrade") {
@@ -138,7 +140,8 @@ export async function deploy(
         args,
         mode,
         profiling,
-        logger
+        logger,
+        origin
       );
     }
     //updatedState.candid = candid_source;
@@ -175,11 +178,13 @@ async function install(
   args: Uint8Array,
   mode: string,
   profiling: boolean,
-  logger: ILoggingStore
+  logger: ILoggingStore,
+  origin: string | undefined
 ): Promise<CanisterInfo> {
   if (!canisterInfo) {
     throw new Error("no canister id");
   }
+  origin ||= "playground";
   const canisterId = canisterInfo.id;
   const installArgs = {
     arg: [...args],
@@ -190,7 +195,8 @@ async function install(
   const installConfig = {
     profiling,
     is_whitelisted: false,
-    origin: "playground",
+    origin,
+    referrer: document.referrer || (window.opener && "(opener)") || undefined,
   };
   const new_info = await backend.installCode(
     canisterInfo,
@@ -199,6 +205,7 @@ async function install(
   );
   canisterInfo = new_info;
   logger.log(`Code installed at canister id ${canisterInfo.id}`);
+  console.log("Installed with origin:", origin);
   return canisterInfo;
 }
 

--- a/src/build.ts
+++ b/src/build.ts
@@ -156,7 +156,7 @@ async function createCanister(
 ): Promise<CanisterInfo> {
   const timestamp = BigInt(Date.now()) * BigInt(1_000_000);
   const nonce = await worker.pow(timestamp);
-  const info = await backend.getCanisterId(nonce);
+  const info = await backend.getCanisterId(nonce, "playground");
   logger.log(`Got canister id ${info.id}`);
   return {
     id: info.id,
@@ -187,11 +187,15 @@ async function install(
     mode: { [mode]: null },
     canister_id: canisterId,
   };
+  const installConfig = {
+    profiling,
+    is_whitelisted: false,
+    origin: "playground",
+  };
   const new_info = await backend.installCode(
     canisterInfo,
     installArgs,
-    profiling,
-    false
+    installConfig
   );
   canisterInfo = new_info;
   logger.log(`Code installed at canister id ${canisterInfo.id}`);

--- a/src/components/CanisterModal.tsx
+++ b/src/components/CanisterModal.tsx
@@ -108,6 +108,10 @@ export function CanisterModal({ isOpen, close, deploySetter }) {
     await deploySetter.setInitTypes(init);
     await deploySetter.setCandidCode(candid);
     await deploySetter.setShowDeployModal(true);
+    await dispatch({
+      type: "setOrigin",
+      payload: { origin: "playground:wasm", tags: [] },
+    });
   }
   async function addCanister() {
     if (error || !canisterName || !canisterId || !candid) {

--- a/src/components/DeployModal.tsx
+++ b/src/components/DeployModal.tsx
@@ -100,6 +100,7 @@ interface DeployModalProps {
   candid: string;
   initTypes: Array<IDL.Type>;
   logger: ILoggingStore;
+  origin: string | undefined;
 }
 
 const MAX_CANISTERS = 3;
@@ -116,6 +117,7 @@ export function DeployModal({
   candid,
   initTypes,
   logger,
+  origin,
 }: DeployModalProps) {
   const [canisterName, setCanisterName] = useState("");
   const [inputs, setInputs] = useState<InputBox[]>([]);
@@ -244,7 +246,8 @@ export function DeployModal({
         mode,
         compileResult.wasm,
         profiling,
-        logger
+        logger,
+        origin
       );
       await isDeploy(false);
       if (info) {

--- a/src/components/ImportGithub.tsx
+++ b/src/components/ImportGithub.tsx
@@ -2,7 +2,10 @@ import styled from "styled-components";
 import { useState, useContext } from "react";
 import { Button } from "./shared/Button";
 import { PackageInfo } from "../workers/file";
-import { WorkerContext } from "../contexts/WorkplaceState";
+import {
+  WorkerContext,
+  WorkplaceDispatchContext,
+} from "../contexts/WorkplaceState";
 import { Field } from "./shared/Field";
 
 const Container = styled.div`
@@ -33,12 +36,17 @@ export function ImportGitHub({ importCode, close, isPackageModal = false }) {
   const [error, setError] = useState("");
   const [name, setName] = useState("");
   const worker = useContext(WorkerContext);
+  const dispatch = useContext(WorkplaceDispatchContext);
   async function fetchCode() {
     const files = await worker.fetchGithub({ repo, branch, dir });
     if (files) {
       setError("");
       importCode(files);
       close();
+      await dispatch({
+        type: "setOrigin",
+        payload: { origin: "playground:git", tags: [`git:${repo}`] },
+      });
     } else {
       setError(`Cannot find repo or the directory contains no ".mo" files.`);
     }

--- a/src/components/ProjectModal.tsx
+++ b/src/components/ProjectModal.tsx
@@ -75,7 +75,7 @@ export function ProjectModal({
     }
     await dispatch({
       type: "setOrigin",
-      payload: { origin: `playground:example:${project.name}` },
+      payload: { origin: "playground", tags: [`example:${project.name}`] },
     });
   }
   async function emptyProject() {
@@ -83,7 +83,7 @@ export function ProjectModal({
     close();
     await dispatch({
       type: "setOrigin",
-      payload: { origin: "playground:new" },
+      payload: { origin: "playground", tags: ["file:new"] },
     });
   }
 

--- a/src/components/ProjectModal.tsx
+++ b/src/components/ProjectModal.tsx
@@ -9,7 +9,10 @@ import { Tab, Tabs } from "./shared/Tabs";
 
 import { ImportGitHub } from "./ImportGithub";
 import { fetchExample, exampleProjects, ExampleProject } from "../examples";
-import { WorkerContext } from "../contexts/WorkplaceState";
+import {
+  WorkerContext,
+  WorkplaceDispatchContext,
+} from "../contexts/WorkplaceState";
 import iconCaretRight from "../assets/images/icon-caret-right.svg";
 
 const ModalContainer = styled.div`
@@ -63,16 +66,25 @@ export function ProjectModal({
   isFirstOpen,
 }: ProjectModalProps) {
   const worker = useContext(WorkerContext);
+  const dispatch = useContext(WorkplaceDispatchContext);
   async function handleSelectProjectAndClose(project: ExampleProject) {
     const files = await fetchExample(worker, project);
     if (files) {
       await importCode(files);
       close();
     }
+    await dispatch({
+      type: "setOrigin",
+      payload: { origin: `playground:example:${project.name}` },
+    });
   }
   async function emptyProject() {
     await importCode({ "Main.mo": "" });
     close();
+    await dispatch({
+      type: "setOrigin",
+      payload: { origin: "playground:new" },
+    });
   }
 
   const welcomeText = (
@@ -123,12 +135,12 @@ export function ProjectModal({
               <ProjectButton onClick={emptyProject}>
                 New Motoko project
               </ProjectButton>
-              {Object.entries(exampleProjects).map(([name, project]) => (
+              {exampleProjects.map((project) => (
                 <ProjectButton
-                  key={name}
+                  key={project.name}
                   onClick={() => handleSelectProjectAndClose(project)}
                 >
-                  {name}
+                  {project.name}
                 </ProjectButton>
               ))}
             </SelectList>

--- a/src/contexts/WorkplaceState.ts
+++ b/src/contexts/WorkplaceState.ts
@@ -8,6 +8,7 @@ export interface WorkplaceState {
   canisters: Record<string, CanisterInfo>;
   selectedCanister: string | null;
   packages: Record<string, PackageInfo>;
+  origin: string | undefined;
 }
 export function getActorAliases(
   canisters: Record<string, CanisterInfo>
@@ -121,8 +122,14 @@ export type WorkplaceReducerAction =
       payload: {
         /** path of file that should be updated. Should correspond to a property in state.files */
         canister: CanisterInfo;
-        do_not_select?: bool;
+        do_not_select?: boolean;
         /** new contents of file */
+      };
+    }
+  | {
+      type: "setOrigin";
+      payload: {
+        origin: string | undefined;
       };
     };
 
@@ -157,6 +164,7 @@ export const workplaceReducer = {
       canisters,
       selectedCanister: null,
       packages: {},
+      origin: undefined,
     };
   },
   /** Return updated state based on an action */
@@ -219,6 +227,13 @@ export const workplaceReducer = {
             ...state.canisters,
             [name]: action.payload.canister,
           },
+        };
+      }
+      case "setOrigin": {
+        const { origin } = action.payload;
+        return {
+          ...state,
+          origin,
         };
       }
       default:

--- a/src/contexts/WorkplaceState.ts
+++ b/src/contexts/WorkplaceState.ts
@@ -2,13 +2,17 @@ import * as React from "react";
 import { CanisterInfo } from "../build";
 import { PackageInfo } from "../workers/file";
 
+export interface Origin {
+  origin: string;
+  tags: Array<string>;
+}
 export interface WorkplaceState {
   files: Record<string, string>;
   selectedFile: string | null;
   canisters: Record<string, CanisterInfo>;
   selectedCanister: string | null;
   packages: Record<string, PackageInfo>;
-  origin: string | undefined;
+  origin: Origin | undefined;
 }
 export function getActorAliases(
   canisters: Record<string, CanisterInfo>
@@ -128,9 +132,7 @@ export type WorkplaceReducerAction =
     }
   | {
       type: "setOrigin";
-      payload: {
-        origin: string | undefined;
-      };
+      payload: Origin;
     };
 
 function selectFirstFile(files: Record<string, string>): string | null {
@@ -230,10 +232,14 @@ export const workplaceReducer = {
         };
       }
       case "setOrigin": {
-        const { origin } = action.payload;
+        let refer =
+          document.referrer || (window.opener && "(opener)") || undefined;
+        if (refer) {
+          action.payload.tags.push(`ref:${refer}`);
+        }
         return {
           ...state,
-          origin,
+          origin: action.payload,
         };
       }
       default:

--- a/src/declarations/backend/backend.did
+++ b/src/declarations/backend/backend.did
@@ -44,16 +44,22 @@ type Self =
     (record {canister_id: canister_id;});
    delete_canister: (record {canister_id: canister_id;}) -> ();
    dump: () -> (vec CanisterInfo) query;
-   getCanisterId: (Nonce) -> (CanisterInfo);
+   getCanisterId: (Nonce, text) -> (CanisterInfo);
    getInitParams: () -> (InitParams) query;
-   getStats: () -> (Stats) query;
+   getStats: () -> (Stats, vec record {
+                                 text;
+                                 nat;
+                               }, vec record {
+                                        text;
+                                        nat;
+                                      }) query;
    getSubtree: (CanisterInfo) ->
     (vec record {
            principal;
            vec CanisterInfo;
          }) query;
    http_request: (HttpRequest) -> (HttpResponse) query;
-   installCode: (CanisterInfo, InstallArgs, bool, bool) -> (CanisterInfo);
+   installCode: (CanisterInfo, InstallArgs, InstallConfig) -> (CanisterInfo);
    install_code:
     (record {
        arg: blob;
@@ -81,6 +87,12 @@ type Nonce =
  record {
    nonce: nat;
    timestamp: int;
+ };
+type InstallConfig = 
+ record {
+   is_whitelisted: bool;
+   origin: text;
+   profiling: bool;
  };
 type InstallArgs = 
  record {

--- a/src/declarations/backend/backend.did
+++ b/src/declarations/backend/backend.did
@@ -44,7 +44,7 @@ type Self =
     (record {canister_id: canister_id;});
    delete_canister: (record {canister_id: canister_id;}) -> ();
    dump: () -> (vec CanisterInfo) query;
-   getCanisterId: (Nonce, text) -> (CanisterInfo);
+   getCanisterId: (Nonce, Origin) -> (CanisterInfo);
    getInitParams: () -> (InitParams) query;
    getStats: () -> (Stats, vec record {
                                  text;
@@ -52,7 +52,10 @@ type Self =
                                }, vec record {
                                         text;
                                         nat;
-                                      }) query;
+                                      }, vec record {
+                                               text;
+                                               nat;
+                                             }) query;
    getSubtree: (CanisterInfo) ->
     (vec record {
            principal;
@@ -83,6 +86,11 @@ type Self =
      }) -> ();
    wallet_receive: () -> ();
  };
+type Origin = 
+ record {
+   origin: text;
+   tags: vec text;
+ };
 type Nonce = 
  record {
    nonce: nat;
@@ -91,7 +99,7 @@ type Nonce =
 type InstallConfig = 
  record {
    is_whitelisted: bool;
-   origin: text;
+   origin: Origin;
    profiling: bool;
  };
 type InstallArgs = 

--- a/src/declarations/backend/backend.did.d.ts
+++ b/src/declarations/backend/backend.did.d.ts
@@ -29,6 +29,11 @@ export interface InstallArgs {
   mode: { reinstall: null } | { upgrade: null } | { install: null };
   canister_id: Principal;
 }
+export interface InstallConfig {
+  origin: string;
+  profiling: boolean;
+  is_whitelisted: boolean;
+}
 export interface Nonce {
   nonce: bigint;
   timestamp: bigint;
@@ -56,16 +61,19 @@ export interface Self {
   >;
   delete_canister: ActorMethod<[{ canister_id: canister_id }], undefined>;
   dump: ActorMethod<[], Array<CanisterInfo>>;
-  getCanisterId: ActorMethod<[Nonce], CanisterInfo>;
+  getCanisterId: ActorMethod<[Nonce, string], CanisterInfo>;
   getInitParams: ActorMethod<[], InitParams>;
-  getStats: ActorMethod<[], Stats>;
+  getStats: ActorMethod<
+    [],
+    [Stats, Array<[string, bigint]>, Array<[string, bigint]>]
+  >;
   getSubtree: ActorMethod<
     [CanisterInfo],
     Array<[Principal, Array<CanisterInfo>]>
   >;
   http_request: ActorMethod<[HttpRequest], HttpResponse>;
   installCode: ActorMethod<
-    [CanisterInfo, InstallArgs, boolean, boolean],
+    [CanisterInfo, InstallArgs, InstallConfig],
     CanisterInfo
   >;
   install_code: ActorMethod<

--- a/src/declarations/backend/backend.did.d.ts
+++ b/src/declarations/backend/backend.did.d.ts
@@ -30,13 +30,17 @@ export interface InstallArgs {
   canister_id: Principal;
 }
 export interface InstallConfig {
-  origin: string;
+  origin: Origin;
   profiling: boolean;
   is_whitelisted: boolean;
 }
 export interface Nonce {
   nonce: bigint;
   timestamp: bigint;
+}
+export interface Origin {
+  origin: string;
+  tags: Array<string>;
 }
 export interface Self {
   GCCanisters: ActorMethod<[], undefined>;
@@ -61,11 +65,16 @@ export interface Self {
   >;
   delete_canister: ActorMethod<[{ canister_id: canister_id }], undefined>;
   dump: ActorMethod<[], Array<CanisterInfo>>;
-  getCanisterId: ActorMethod<[Nonce, string], CanisterInfo>;
+  getCanisterId: ActorMethod<[Nonce, Origin], CanisterInfo>;
   getInitParams: ActorMethod<[], InitParams>;
   getStats: ActorMethod<
     [],
-    [Stats, Array<[string, bigint]>, Array<[string, bigint]>]
+    [
+      Stats,
+      Array<[string, bigint]>,
+      Array<[string, bigint]>,
+      Array<[string, bigint]>
+    ]
   >;
   getSubtree: ActorMethod<
     [CanisterInfo],

--- a/src/declarations/backend/backend.did.js
+++ b/src/declarations/backend/backend.did.js
@@ -53,6 +53,11 @@ export const idlFactory = ({ IDL }) => {
     }),
     canister_id: IDL.Principal,
   });
+  const InstallConfig = IDL.Record({
+    origin: IDL.Text,
+    profiling: IDL.Bool,
+    is_whitelisted: IDL.Bool,
+  });
   const wasm_module = IDL.Vec(IDL.Nat8);
   const Self = IDL.Service({
     GCCanisters: IDL.Func([], [], ["oneway"]),
@@ -90,9 +95,17 @@ export const idlFactory = ({ IDL }) => {
       []
     ),
     dump: IDL.Func([], [IDL.Vec(CanisterInfo)], ["query"]),
-    getCanisterId: IDL.Func([Nonce], [CanisterInfo], []),
+    getCanisterId: IDL.Func([Nonce, IDL.Text], [CanisterInfo], []),
     getInitParams: IDL.Func([], [InitParams], ["query"]),
-    getStats: IDL.Func([], [Stats], ["query"]),
+    getStats: IDL.Func(
+      [],
+      [
+        Stats,
+        IDL.Vec(IDL.Tuple(IDL.Text, IDL.Nat)),
+        IDL.Vec(IDL.Tuple(IDL.Text, IDL.Nat)),
+      ],
+      ["query"]
+    ),
     getSubtree: IDL.Func(
       [CanisterInfo],
       [IDL.Vec(IDL.Tuple(IDL.Principal, IDL.Vec(CanisterInfo)))],
@@ -100,7 +113,7 @@ export const idlFactory = ({ IDL }) => {
     ),
     http_request: IDL.Func([HttpRequest], [HttpResponse], ["query"]),
     installCode: IDL.Func(
-      [CanisterInfo, InstallArgs, IDL.Bool, IDL.Bool],
+      [CanisterInfo, InstallArgs, InstallConfig],
       [CanisterInfo],
       []
     ),

--- a/src/declarations/backend/backend.did.js
+++ b/src/declarations/backend/backend.did.js
@@ -24,6 +24,10 @@ export const idlFactory = ({ IDL }) => {
     compute_allocation: IDL.Opt(IDL.Nat),
   });
   const Nonce = IDL.Record({ nonce: IDL.Nat, timestamp: IDL.Int });
+  const Origin = IDL.Record({
+    origin: IDL.Text,
+    tags: IDL.Vec(IDL.Text),
+  });
   const Stats = IDL.Record({
     num_of_installs: IDL.Nat,
     num_of_canisters: IDL.Nat,
@@ -54,7 +58,7 @@ export const idlFactory = ({ IDL }) => {
     canister_id: IDL.Principal,
   });
   const InstallConfig = IDL.Record({
-    origin: IDL.Text,
+    origin: Origin,
     profiling: IDL.Bool,
     is_whitelisted: IDL.Bool,
   });
@@ -95,12 +99,13 @@ export const idlFactory = ({ IDL }) => {
       []
     ),
     dump: IDL.Func([], [IDL.Vec(CanisterInfo)], ["query"]),
-    getCanisterId: IDL.Func([Nonce, IDL.Text], [CanisterInfo], []),
+    getCanisterId: IDL.Func([Nonce, Origin], [CanisterInfo], []),
     getInitParams: IDL.Func([], [InitParams], ["query"]),
     getStats: IDL.Func(
       [],
       [
         Stats,
+        IDL.Vec(IDL.Tuple(IDL.Text, IDL.Nat)),
         IDL.Vec(IDL.Tuple(IDL.Text, IDL.Nat)),
         IDL.Vec(IDL.Tuple(IDL.Text, IDL.Nat)),
       ],

--- a/src/declarations/react_app/react_app.did
+++ b/src/declarations/react_app/react_app.did
@@ -109,6 +109,18 @@ type SetAssetPropertiesArguments = record {
   is_aliased: opt opt bool;
 };
 
+type ConfigurationResponse = record {
+  max_batches: opt nat64;
+  max_chunks: opt nat64;
+  max_bytes: opt nat64;
+};
+
+type ConfigureArguments = record {
+  max_batches: opt opt nat64;
+  max_chunks: opt opt nat64;
+  max_bytes: opt opt nat64;
+};
+
 type Permission = variant {
   Commit;
   ManagePermissions;
@@ -221,8 +233,12 @@ service: {
     is_aliased: opt bool; } ) query;
   set_asset_properties: (SetAssetPropertiesArguments) -> ();
 
+  get_configuration: () -> (ConfigurationResponse);
+  configure: (ConfigureArguments) -> ();
+
   validate_grant_permission: (GrantPermission) -> (ValidationResult);
   validate_revoke_permission: (RevokePermission) -> (ValidationResult);
   validate_take_ownership: () -> (ValidationResult);
   validate_commit_proposed_batch: (CommitProposedBatchArguments) -> (ValidationResult);
+  validate_configure: (ConfigureArguments) -> (ValidationResult);
 }

--- a/src/declarations/react_app/react_app.did.d.ts
+++ b/src/declarations/react_app/react_app.did.d.ts
@@ -25,6 +25,16 @@ export interface ComputeEvidenceArguments {
   batch_id: BatchId;
   max_iterations: [] | [number];
 }
+export interface ConfigurationResponse {
+  max_batches: [] | [bigint];
+  max_bytes: [] | [bigint];
+  max_chunks: [] | [bigint];
+}
+export interface ConfigureArguments {
+  max_batches: [] | [[] | [bigint]];
+  max_bytes: [] | [[] | [bigint]];
+  max_chunks: [] | [[] | [bigint]];
+}
 export interface CreateAssetArguments {
   key: Key;
   content_type: string;
@@ -118,6 +128,7 @@ export interface _SERVICE {
     [ComputeEvidenceArguments],
     [] | [Uint8Array | number[]]
   >;
+  configure: ActorMethod<[ConfigureArguments], undefined>;
   create_asset: ActorMethod<[CreateAssetArguments], undefined>;
   create_batch: ActorMethod<[{}], { batch_id: BatchId }>;
   create_chunk: ActorMethod<
@@ -157,6 +168,7 @@ export interface _SERVICE {
     ],
     { content: Uint8Array | number[] }
   >;
+  get_configuration: ActorMethod<[], ConfigurationResponse>;
   grant_permission: ActorMethod<[GrantPermission], undefined>;
   http_request: ActorMethod<[HttpRequest], HttpResponse>;
   http_request_streaming_callback: ActorMethod<
@@ -200,6 +212,7 @@ export interface _SERVICE {
     [CommitProposedBatchArguments],
     ValidationResult
   >;
+  validate_configure: ActorMethod<[ConfigureArguments], ValidationResult>;
   validate_grant_permission: ActorMethod<[GrantPermission], ValidationResult>;
   validate_revoke_permission: ActorMethod<[RevokePermission], ValidationResult>;
   validate_take_ownership: ActorMethod<[], ValidationResult>;

--- a/src/declarations/react_app/react_app.did.js
+++ b/src/declarations/react_app/react_app.did.js
@@ -50,7 +50,17 @@ export const idlFactory = ({ IDL }) => {
     batch_id: BatchId,
     max_iterations: IDL.Opt(IDL.Nat16),
   });
+  const ConfigureArguments = IDL.Record({
+    max_batches: IDL.Opt(IDL.Opt(IDL.Nat64)),
+    max_bytes: IDL.Opt(IDL.Opt(IDL.Nat64)),
+    max_chunks: IDL.Opt(IDL.Opt(IDL.Nat64)),
+  });
   const DeleteBatchArguments = IDL.Record({ batch_id: BatchId });
+  const ConfigurationResponse = IDL.Record({
+    max_batches: IDL.Opt(IDL.Nat64),
+    max_bytes: IDL.Opt(IDL.Nat64),
+    max_chunks: IDL.Opt(IDL.Nat64),
+  });
   const Permission = IDL.Variant({
     Prepare: IDL.Null,
     ManagePermissions: IDL.Null,
@@ -121,6 +131,7 @@ export const idlFactory = ({ IDL }) => {
       [IDL.Opt(IDL.Vec(IDL.Nat8))],
       []
     ),
+    configure: IDL.Func([ConfigureArguments], [], []),
     create_asset: IDL.Func([CreateAssetArguments], [], []),
     create_batch: IDL.Func(
       [IDL.Record({})],
@@ -172,6 +183,7 @@ export const idlFactory = ({ IDL }) => {
       [IDL.Record({ content: IDL.Vec(IDL.Nat8) })],
       ["query"]
     ),
+    get_configuration: IDL.Func([], [ConfigurationResponse], []),
     grant_permission: IDL.Func([GrantPermission], [], []),
     http_request: IDL.Func([HttpRequest], [HttpResponse], ["query"]),
     http_request_streaming_callback: IDL.Func(
@@ -229,6 +241,7 @@ export const idlFactory = ({ IDL }) => {
       [ValidationResult],
       []
     ),
+    validate_configure: IDL.Func([ConfigureArguments], [ValidationResult], []),
     validate_grant_permission: IDL.Func(
       [GrantPermission],
       [ValidationResult],

--- a/src/examples.ts
+++ b/src/examples.ts
@@ -1,6 +1,7 @@
 import { RepoInfo } from "./workers/file";
 
 export interface ExampleProject {
+  name: string;
   repo: RepoInfo;
   readme?: string;
 }
@@ -12,52 +13,63 @@ const example = {
 const readmeURL =
   "https://raw.githubusercontent.com/dfinity/examples/master/motoko";
 
-export const exampleProjects: Record<string, ExampleProject> = {
-  "Hello, world": {
+export const exampleProjects: ExampleProject[] = [
+  {
+    name: "Hello, world",
     repo: { dir: "motoko/echo/src", ...example },
     readme: `${readmeURL}/echo/README.md`,
   },
-  Counter: {
+  {
+    name: "Counter",
     repo: { dir: "motoko/counter/src", ...example },
     readme: `${readmeURL}/counter/README.md`,
   },
-  Calculator: {
+  {
+    name: "Calculator",
     repo: { dir: "motoko/calc/src", ...example },
     readme: `${readmeURL}/calc/README.md`,
   },
-  "Who am I?": {
+  {
+    name: "Who am I?",
     repo: { dir: "motoko/whoami/src", ...example },
     readme: `${readmeURL}/whoami/README.md`,
   },
-  "Phone Book": {
+  {
+    name: "Phone Book",
     repo: { dir: "motoko/phone-book/src/phone-book", ...example },
     readme: `${readmeURL}/phone-book/README.md`,
   },
-  "Super Heroes": {
+  {
+    name: "Super Heroes",
     repo: { dir: "motoko/superheroes/src/superheroes", ...example },
     readme: `${readmeURL}/superheroes/README.md`,
   },
-  "Random Maze": {
+  {
+    name: "Random Maze",
     repo: { dir: "motoko/random_maze/src/random_maze", ...example },
     readme: `${readmeURL}/random_maze/README.md`,
   },
-  "Game of Life": {
+  {
+    name: "Game of Life",
     repo: { dir: "motoko/life", ...example },
     readme: `${readmeURL}/life/README.md`,
   },
-  "Publisher and Subscriber": {
+  {
+    name: "Publisher and Subscriber",
     repo: { dir: "motoko/pub-sub/src", ...example },
     readme: `${readmeURL}/pub-sub/README.md`,
   },
-  "Actor Classes": {
+  {
+    name: "Actor Classes",
     repo: { dir: "motoko/classes/src", ...example },
     readme: `${readmeURL}/classes/README.md`,
   },
-  "Basic DAO": {
+  {
+    name: "Basic DAO",
     repo: { dir: "motoko/basic_dao/src", ...example },
     readme: `${readmeURL}/basic_dao/README.md`,
   },
-};
+];
 
 export async function fetchExample(
   worker,

--- a/src/integrations/allowedOrigins.ts
+++ b/src/integrations/allowedOrigins.ts
@@ -2,7 +2,7 @@
 // please submit a PR including the URL prefix for your application.
 // Read more: https://developer.mozilla.org/en-US/docs/Web/API/Window/postMessage#security_concerns
 
-const ALLOWED_ORIGINS = [
+const ALLOWED_ORIGINS: (string | RegExp)[] = [
   /^https?:\/\/(localhost|127\.0\.0\.1)(:[0-9]+)?$/, // Localhost
   "https://blocks-editor.github.io", // Blocks (visual Motoko smart contract editor)
 ];

--- a/src/integrations/editorIntegration.ts
+++ b/src/integrations/editorIntegration.ts
@@ -18,6 +18,11 @@ type EditorIntegrationResponse = {
   acknowledge: number;
 };
 
+export interface EditorIntegrationResult {
+  origin: string;
+  files: Record<string, string>;
+}
+
 export const INTEGRATION_HOOKS: Partial<EditorIntegrationHooks> = {};
 
 // Cached return value to ensure at most one initialization
@@ -35,7 +40,7 @@ export async function setupEditorIntegration(
   editorKey: string,
   dispatch: (WorkplaceReducerAction) => void,
   worker // MocWorker
-): Promise<Record<string, string> | undefined> {
+): Promise<EditorIntegrationResult | undefined> {
   if (previousResult) {
     return previousResult;
   }
@@ -111,7 +116,10 @@ export async function setupEditorIntegration(
 
   // Load a default empty project
   previousResult = {
-    "Main.mo": "",
+    origin,
+    files: {
+      "Main.mo": "",
+    },
   };
   return previousResult;
 }


### PR DESCRIPTION
* `origin = playground | playground:git | playground:tag | playground:wasm | playground:post:blocks | dfx`
* Tags are only set in install.
  + Set by frontend: `tags = git:{repo} | tag:{id} | example:{name} | file:new | ref:{url}`
  + Set by backend: `tags = profiling | install | upgrade | reinstall | asset`