### PR TITLE
refactor stats

### DIFF
--- a/service/pool/Logs.mo
+++ b/service/pool/Logs.mo
@@ -7,71 +7,58 @@ import {get} "mo:base/Option";
 
 module {
     public type Origin = { origin: Text; tags: [Text] };
-    public type SharedStatsByOrigin = (Map.Tree<Text,Nat>, Map.Tree<Text,Nat>, Map.Tree<Text, Nat>);
+    public type SharedStatsByOrigin = (Map.Tree<Text,Nat>, Map.Tree<Text,Nat>);
     public class StatsByOrigin() {
         var canisters = Map.RBTree<Text, Nat>(compare);
         var installs = Map.RBTree<Text, Nat>(compare);
-        var tags = Map.RBTree<Text, Nat>(compare);
-        public func share() : SharedStatsByOrigin = (canisters.share(), installs.share(), tags.share());
+        public func share() : SharedStatsByOrigin = (canisters.share(), installs.share());
         public func unshare(x : SharedStatsByOrigin) {
             canisters.unshare(x.0);
             installs.unshare(x.1);
-            tags.unshare(x.2);
         };
-        func addTags(list: [Text]) {
+        func addTags(map: Map.RBTree<Text,Nat>, list: [Text]) {
             for (tag in list.vals()) {
-                switch (tags.get(tag)) {
-                case null { tags.put(tag, 1) };
-                case (?n) { tags.put(tag, n + 1) };
+                switch (map.get(tag)) {
+                case null { map.put(tag, 1) };
+                case (?n) { map.put(tag, n + 1) };
                 };
             };
         };
         public func addCanister(origin: Origin) {
-            switch (canisters.get(origin.origin)) {
-            case null { canisters.put(origin.origin, 1) };
-            case (?n) { canisters.put(origin.origin, n + 1) };
-            };
-            // Not storing tags for create canister to avoid duplicate counting of tags
-            // addTags(origin.tags);
+            addTags(canisters, ["origin:" # origin.origin]);
+            addTags(canisters, origin.tags);
         };
         public func addInstall(origin: Origin) {
-            switch (installs.get(origin.origin)) {
-            case null { installs.put(origin.origin, 1) };
-            case (?n) { installs.put(origin.origin, n + 1) };
-            };
-            // Only record tags for canister install
-            addTags(origin.tags);
+            addTags(installs, ["origin:" # origin.origin]);
+            addTags(installs, origin.tags);
         };
-        public func dump() : ([(Text, Nat)], [(Text, Nat)], [(Text, Nat)]) {
+        public func dump() : ([(Text, Nat)], [(Text, Nat)]) {
             (toArray<(Text, Nat)>(canisters.entries()),
              toArray<(Text, Nat)>(installs.entries()),
-             toArray<(Text, Nat)>(tags.entries())
             )
         };
         public func metrics() : Text {
             var result = "";
             let now = timeNow() / 1_000_000;
-            for ((origin, count) in canisters.entries()) {
-                let name = "canisters_" # origin;
-                let desc = "Number of canisters requested from " # origin;
-                result := result # encode_single_value("counter", name, count, desc, now);
-            };
-            for ((origin, count) in installs.entries()) {
-                let name = "installs_" # origin;
-                let desc = "Number of Wasm installed from " # origin;
-                result := result # encode_single_value("counter", name, count, desc, now);
-            };
-            let profiling = get(tags.get("profiling"), 0);
-            let asset = get(tags.get("asset"), 0);
-            let install = get(tags.get("install"), 0);
-            let reinstall = get(tags.get("reinstall"), 0);
-            let upgrade = get(tags.get("upgrade"), 0);
+            let canister_playground = get(canisters.get("origin:playground"), 0);
+            let canister_dfx = get(canisters.get("origin:dfx"), 0);
+            let install_playground = get(installs.get("origin:playground"), 0);
+            let install_dfx = get(installs.get("origin:dfx"), 0);
+            let profiling = get(installs.get("wasm:profiling"), 0);
+            let asset = get(installs.get("wasm:asset"), 0);
+            let install = get(installs.get("wasm:install"), 0);
+            let reinstall = get(installs.get("wasm:reinstall"), 0);
+            let upgrade = get(installs.get("wasm:upgrade"), 0);
             result := result
-            # encode_single_value("counter", "profiling", profiling, "Number of Wasm profiled", now)
-            # encode_single_value("counter", "asset", asset, "Number of asset Wasm canister installed", now)
-            # encode_single_value("counter", "install", install, "Number of Wasm with install mode", now)
-            # encode_single_value("counter", "reinstall", reinstall, "Number of Wasm with reinstall mode", now)
-            # encode_single_value("counter", "upgrade", upgrade, "Number of Wasm with upgrad mode", now);
+            # encode_single_value("counter", "create_from_playground", canister_playground, "Number of canisters created from playground", now)
+            # encode_single_value("counter", "install_from_playground", install_playground, "Number of Wasms installed from playground", now)
+            # encode_single_value("counter", "create_from_dfx", canister_dfx, "Number of canisters created from dfx", now)
+            # encode_single_value("counter", "install_from_dfx", install_dfx, "Number of Wasms installed from dfx", now)
+            # encode_single_value("counter", "profiling", profiling, "Number of Wasms profiled", now)
+            # encode_single_value("counter", "asset", asset, "Number of asset Wasms canister installed", now)
+            # encode_single_value("counter", "install", install, "Number of Wasms with install mode", now)
+            # encode_single_value("counter", "reinstall", reinstall, "Number of Wasms with reinstall mode", now)
+            # encode_single_value("counter", "upgrade", upgrade, "Number of Wasms with upgrad mode", now);
             result;
         };
     };

--- a/service/pool/Main.mo
+++ b/service/pool/Main.mo
@@ -33,7 +33,7 @@ shared (creator) actor class Self(opt_params : ?Types.InitParams) = this {
     stable var stableChildren : [(Principal, [Principal])] = [];
     stable var stableTimers : [Types.CanisterInfo] = [];
     stable var previousParam : ?Types.InitParams = null;
-    stable var stableStatsByOrigin : Logs.SharedStatsByOrigin = (#leaf, #leaf, #leaf);
+    stable var stableStatsByOrigin : Logs.SharedStatsByOrigin = (#leaf, #leaf);
 
     system func preupgrade() {
         let (tree, metadata, children, timers) = pool.share();
@@ -62,9 +62,9 @@ shared (creator) actor class Self(opt_params : ?Types.InitParams) = this {
         params;
     };
 
-    public query func getStats() : async (Logs.Stats, [(Text, Nat)], [(Text, Nat)], [(Text, Nat)]) {
-        let (canister, install, tags) = statsByOrigin.dump();
-        (stats, canister, install, tags);
+    public query func getStats() : async (Logs.Stats, [(Text, Nat)], [(Text, Nat)]) {
+        let (canister, install) = statsByOrigin.dump();
+        (stats, canister, install);
     };
 
     public query func balance() : async Nat {
@@ -174,15 +174,15 @@ shared (creator) actor class Self(opt_params : ?Types.InitParams) = this {
             // Build tags from install arguments
             let tags = Buffer.fromArray<Text>(install_config.origin.tags);
             if (install_config.profiling) {
-                tags.add("profiling");
+                tags.add("wasm:profiling");
             };
             if (install_config.is_whitelisted) {
-                tags.add("asset");
+                tags.add("wasm:asset");
             };
             switch (args.mode) {
-            case (#install) { tags.add("install") };
-            case (#upgrade) { tags.add("upgrade") };
-            case (#reinstall) { tags.add("reinstall") };
+            case (#install) { tags.add("wasm:install") };
+            case (#upgrade) { tags.add("wasm:upgrade") };
+            case (#reinstall) { tags.add("wasm:reinstall") };
             };
             let origin = { origin = install_config.origin.origin; tags = Buffer.toArray(tags) };
             statsByOrigin.addInstall(origin);

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -82,7 +82,7 @@ async function fetchFromUrlParams(
       const { origin, files } = result;
       await dispatch({
         type: "setOrigin",
-        payload: { origin: `playground:post:${origin}`, tags: [] },
+        payload: { origin: "playground", tags: [`post:${origin}`] },
       });
       return files;
     }
@@ -95,7 +95,7 @@ async function fetchFromUrlParams(
     };
     await dispatch({
       type: "setOrigin",
-      payload: { origin: "playground:git", tags: [`git:${git}`] },
+      payload: { origin: "playground", tags: [`git:${git}`] },
     });
     return await worker.fetchGithub(repo);
   }
@@ -147,7 +147,7 @@ async function fetchFromUrlParams(
       }
       await dispatch({
         type: "setOrigin",
-        payload: { origin: "playground:tag", tags: [`tag:${tag}`] },
+        payload: { origin: "playground", tags: [`tag:${tag}`] },
       });
       return files;
     }

--- a/src/build.ts
+++ b/src/build.ts
@@ -154,6 +154,14 @@ export async function deploy(
   }
 }
 
+function mkOrigin(origin: Origin, is_install: boolean) {
+  const tags =
+    origin.session_tags && is_install
+      ? origin.tags.concat(origin.session_tags)
+      : origin.tags;
+  return { origin: origin.origin, tags: [...new Set(tags)] };
+}
+
 async function createCanister(
   worker,
   logger: ILoggingStore,
@@ -161,9 +169,7 @@ async function createCanister(
 ): Promise<CanisterInfo> {
   const timestamp = BigInt(Date.now()) * BigInt(1_000_000);
   const nonce = await worker.pow(timestamp);
-  // remove tags for create canister to avoid duplicate counting
-  const no_tags = { origin: origin.origin, tags: [] };
-  const info = await backend.getCanisterId(nonce, no_tags);
+  const info = await backend.getCanisterId(nonce, mkOrigin(origin, false));
   logger.log(`Got canister id ${info.id}`);
   return {
     id: info.id,
@@ -198,7 +204,7 @@ async function install(
   const installConfig = {
     profiling,
     is_whitelisted: false,
-    origin,
+    origin: mkOrigin(origin, true),
   };
   const new_info = await backend.installCode(
     canisterInfo,

--- a/src/components/CanisterModal.tsx
+++ b/src/components/CanisterModal.tsx
@@ -110,7 +110,7 @@ export function CanisterModal({ isOpen, close, deploySetter }) {
     await deploySetter.setShowDeployModal(true);
     await dispatch({
       type: "setOrigin",
-      payload: { origin: "playground:wasm", tags: [] },
+      payload: { origin: "playground", tags: [`upload:wasm`] },
     });
   }
   async function addCanister() {

--- a/src/components/ImportGithub.tsx
+++ b/src/components/ImportGithub.tsx
@@ -45,7 +45,7 @@ export function ImportGitHub({ importCode, close, isPackageModal = false }) {
       close();
       await dispatch({
         type: "setOrigin",
-        payload: { origin: "playground:git", tags: [`git:${repo}`] },
+        payload: { origin: "playground", tags: [`git:${repo}`] },
       });
     } else {
       setError(`Cannot find repo or the directory contains no ".mo" files.`);

--- a/src/contexts/WorkplaceState.ts
+++ b/src/contexts/WorkplaceState.ts
@@ -5,6 +5,8 @@ import { PackageInfo } from "../workers/file";
 export interface Origin {
   origin: string;
   tags: Array<string>;
+  // only added for install_code, and will be clear after each deploy
+  session_tags?: Array<string>;
 }
 export interface WorkplaceState {
   files: Record<string, string>;
@@ -12,7 +14,7 @@ export interface WorkplaceState {
   canisters: Record<string, CanisterInfo>;
   selectedCanister: string | null;
   packages: Record<string, PackageInfo>;
-  origin: Origin | undefined;
+  origin: Origin;
 }
 export function getActorAliases(
   canisters: Record<string, CanisterInfo>
@@ -133,6 +135,13 @@ export type WorkplaceReducerAction =
   | {
       type: "setOrigin";
       payload: Origin;
+    }
+  | {
+      type: "addSessionTag";
+      payload: string;
+    }
+  | {
+      type: "clearSessionTags";
     };
 
 function selectFirstFile(files: Record<string, string>): string | null {
@@ -166,7 +175,7 @@ export const workplaceReducer = {
       canisters,
       selectedCanister: null,
       packages: {},
-      origin: undefined,
+      origin: { origin: "playground", tags: [], session_tags: [] },
     };
   },
   /** Return updated state based on an action */
@@ -240,6 +249,24 @@ export const workplaceReducer = {
         return {
           ...state,
           origin: action.payload,
+        };
+      }
+      case "addSessionTag": {
+        if (state.origin.session_tags) {
+          state.origin.session_tags.push(action.payload);
+        } else {
+          state.origin.session_tags = [action.payload];
+        }
+        return state;
+      }
+      case "clearSessionTags": {
+        return {
+          ...state,
+          origin: {
+            origin: state.origin.origin,
+            tags: state.origin.tags,
+            session_tags: [],
+          },
         };
       }
       default:


### PR DESCRIPTION
* LogsByOrigin now only contains canister and wasm level key-value stores. There is no need to have a dedicated origin key-value store.