### PR TITLE
Fix editor integration origin tags

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -79,11 +79,7 @@ async function fetchFromUrlParams(
   if (editorKey) {
     const result = await setupEditorIntegration(editorKey, dispatch, worker);
     if (result) {
-      const { origin, files } = result;
-      await dispatch({
-        type: "setOrigin",
-        payload: { origin: "playground", tags: [`post:${origin}`] },
-      });
+      const { files } = result;
       return files;
     }
   }

--- a/src/integrations/editorIntegration.ts
+++ b/src/integrations/editorIntegration.ts
@@ -19,7 +19,6 @@ type EditorIntegrationResponse = {
 };
 
 export interface EditorIntegrationResult {
-  origin: string;
   files: Record<string, string>;
 }
 
@@ -106,6 +105,11 @@ export async function setupEditorIntegration(
             });
           }
         }
+
+        await dispatch({
+          type: "setOrigin",
+          payload: { origin: "playground", tags: [`post:${origin}`] },
+        });
       } catch (e) {
         console.error("Error in editor integration message listener:");
         console.error(e);
@@ -116,7 +120,6 @@ export async function setupEditorIntegration(
 
   // Load a default empty project
   previousResult = {
-    origin,
     files: {
       "Main.mo": "",
     },


### PR DESCRIPTION
This PR fixes a rather subtle bug with the `post:*` metric origin, which previously used the global `window.origin` instead of the intended local variable. 
