### PR TITLE
Fix adaptive chart heights on stats page

### DIFF
--- a/src/components/Chart.tsx
+++ b/src/components/Chart.tsx
@@ -15,7 +15,7 @@ export function Chart({ title, data }) {
           data={data}
           options={options}
           width="100%"
-          height="{100 * (data.length - 1)}px"
+          height={`${80 * (data.length - 1)}px`}
           legendToggle
         />
       ) : null}


### PR DESCRIPTION
Uses a tempate string for the chart height, and slightly reduces the height per item for compactness. 