### PR TITLE
Refactoring for Vite migration

### DIFF
--- a/dfx.json
+++ b/dfx.json
@@ -40,5 +40,6 @@
       "output": "build",
       "packtool": "mops sources"
     }
-  }
+  },
+  "output_env_file": ".env"
 }

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "motoko-playground",
   "version": "0.1.0",
   "private": true,
+  "type": "module",
   "dependencies": {
     "@dfinity/agent": "^2.0.0",
     "@dfinity/candid": "^2.0.0",

--- a/src/config/monacoConfig.js
+++ b/src/config/monacoConfig.js
@@ -1,34 +1,28 @@
 import { configure } from "motoko/contrib/monaco";
 import prettier from "prettier";
-
+import * as motokoPlugin from "prettier-plugin-motoko/src/environments/web";
 import errorCodes from "motoko/contrib/generated/errorCodes.json";
-//const errorCodes = require("motoko/contrib/generated/errorCodes.json");
 
 export const configureMonaco = (monaco) => {
   configure(monaco, {
     snippets: true,
   });
 
-  // Asynchronously load WASM
-  import("prettier-plugin-motoko/lib/environments/web")
-    .then((motokoPlugin) => {
-      monaco.languages.registerDocumentFormattingEditProvider("motoko", {
-        provideDocumentFormattingEdits(model, options, token) {
-          const source = model.getValue();
-          const formatted = prettier.format(source, {
-            plugins: [motokoPlugin],
-            filepath: "*.mo",
-          });
-          return [
-            {
-              range: model.getFullModelRange(),
-              text: formatted,
-            },
-          ];
-        },
+  monaco.languages.registerDocumentFormattingEditProvider("motoko", {
+    provideDocumentFormattingEdits(model, options, token) {
+      const source = model.getValue();
+      const formatted = prettier.format(source, {
+        plugins: [motokoPlugin],
+        filepath: "*.mo",
       });
-    })
-    .catch((err) => console.error(err));
+      return [
+        {
+          range: model.getFullModelRange(),
+          text: formatted,
+        },
+      ];
+    },
+  });
 
   monaco.languages.registerHoverProvider("motoko", {
     provideHover(model, position, ...args) {

--- a/src/setupProxy.js
+++ b/src/setupProxy.js
@@ -1,6 +1,6 @@
-const { createProxyMiddleware } = require("http-proxy-middleware");
+import { createProxyMiddleware } from "http-proxy-middleware";
 
-module.exports = (app) => {
+export default (app) => {
   app.use(
     "/api",
     createProxyMiddleware({

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -23,9 +23,6 @@ export default defineConfig(({ mode }) => {
 			},
 			external: ["/moc.js"],
 		},
-		commonjsOptions: {
-			transformMixedEsModules: true,
-		},	
 	},
     plugins: [
       react(),

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -22,7 +22,10 @@ export default defineConfig(({ mode }) => {
 			  moc: resolve(__dirname, 'src/workers/moc.ts'),
 			},
 			external: ["/moc.js"],
-		},		
+		},
+		commonjsOptions: {
+			transformMixedEsModules: true,
+		},	
 	},
     plugins: [
       react(),


### PR DESCRIPTION
Various changes to merge into #248:

* Enables dfx `output_env_file` to fix missing environment variables in dev server.
* Converts the project to use ES Modules, since CommonJS is deprecated in Vite.
* Simplifies the `prettier-plugin-motoko` import.
