### PR TITLE
More refactoring for Vite migration

### DIFF
--- a/src/workers/file.ts
+++ b/src/workers/file.ts
@@ -1,4 +1,4 @@
-declare var Motoko: any;
+import { loadMoc } from "./mocShim";
 
 interface ExtraFile {
   match: RegExp;
@@ -29,6 +29,7 @@ export interface RepoInfo {
 }
 
 export async function fetchPackage(info: PackageInfo): Promise<boolean> {
+  const Motoko = await loadMoc();
   if (
     !info.repo.startsWith("https://github.com/") ||
     !info.repo.endsWith(".git")
@@ -65,7 +66,8 @@ export async function fetchGithub(
   return await fetchFromGithub(repo, target_dir);
 }
 
-export function saveWorkplaceToMotoko(files: Record<string, string>) {
+export async function saveWorkplaceToMotoko(files: Record<string, string>) {
+  const Motoko = await loadMoc();
   for (const [name, code] of Object.entries(files)) {
     if (!name.endsWith("mo")) continue;
     Motoko.saveFile(name, code);
@@ -76,6 +78,7 @@ async function fetchFromCDN(
   repo: RepoInfo,
   target_dir = ""
 ): Promise<Record<string, string> | undefined> {
+  const Motoko = await loadMoc();
   const meta_url = `https://data.jsdelivr.com/v1/package/gh/${repo.repo}@${repo.branch}/flat`;
   const base_url = `https://cdn.jsdelivr.net/gh/${repo.repo}@${repo.branch}`;
   const response = await fetch(meta_url);
@@ -117,6 +120,7 @@ async function fetchFromGithub(
   repo: RepoInfo,
   target_dir = ""
 ): Promise<Record<string, string> | undefined> {
+  const Motoko = await loadMoc();
   const meta_url = `https://api.github.com/repos/${repo.repo}/git/trees/${repo.branch}?recursive=1`;
   const base_url = `https://raw.githubusercontent.com/${repo.repo}/${repo.branch}/`;
   const response = await fetch(meta_url);

--- a/src/workers/mocShim.js
+++ b/src/workers/mocShim.js
@@ -1,6 +1,6 @@
 let Motoko;
 
-const loadMoc = async () => {
+export const loadMoc = async () => {
   if (!Motoko) {
     const scriptUrl = new URL("/moc.js", self.location.origin);
     const response = await fetch(scriptUrl);
@@ -13,5 +13,3 @@ const loadMoc = async () => {
   }
   return Motoko;
 };
-
-export { loadMoc };

--- a/src/workers/mocShim.js
+++ b/src/workers/mocShim.js
@@ -1,15 +1,17 @@
-let Motoko;
+let mocPromise;
 
 export const loadMoc = async () => {
-  if (!Motoko) {
-    const scriptUrl = new URL("/moc.js", self.location.origin);
-    const response = await fetch(scriptUrl);
-    const scriptContent = await response.text();
+  if (!mocPromise) {
+    mocPromise = (async () => {
+      const scriptUrl = new URL("/moc.js", self.location.origin);
+      const response = await fetch(scriptUrl);
+      const scriptContent = await response.text();
 
-    // Execute the script content
-    self.eval(scriptContent);
+      // Execute the script content
+      self.eval(scriptContent);
 
-    Motoko = self.Motoko;
+      return self.Motoko;
+    })();
   }
-  return Motoko;
+  return mocPromise;
 };

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -34,6 +34,9 @@ export default defineConfig(({ mode }) => {
 
       setupProxyPlugin(),
     ],
+    define: {
+      global: "globalThis",
+    },
     worker: {
       format: "es",
     },
@@ -43,7 +46,7 @@ export default defineConfig(({ mode }) => {
         {
           find: "declarations",
           replacement: fileURLToPath(
-            new URL("./src/declarations", import.meta.url),
+            new URL("./src/declarations", import.meta.url)
           ),
         },
       ],
@@ -63,7 +66,7 @@ function devServerPlugin(): Plugin {
       const { HOST, PORT, HTTPS, SSL_CRT_FILE, SSL_KEY_FILE } = loadEnv(
         mode,
         ".",
-        ["HOST", "PORT", "HTTPS", "SSL_CRT_FILE", "SSL_KEY_FILE"],
+        ["HOST", "PORT", "HTTPS", "SSL_CRT_FILE", "SSL_KEY_FILE"]
       );
       const https = HTTPS === "true";
       return {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -46,7 +46,7 @@ export default defineConfig(({ mode }) => {
         {
           find: "declarations",
           replacement: fileURLToPath(
-            new URL("./src/declarations", import.meta.url)
+            new URL("./src/declarations", import.meta.url),
           ),
         },
       ],
@@ -66,7 +66,7 @@ function devServerPlugin(): Plugin {
       const { HOST, PORT, HTTPS, SSL_CRT_FILE, SSL_KEY_FILE } = loadEnv(
         mode,
         ".",
-        ["HOST", "PORT", "HTTPS", "SSL_CRT_FILE", "SSL_KEY_FILE"]
+        ["HOST", "PORT", "HTTPS", "SSL_CRT_FILE", "SSL_KEY_FILE"],
       );
       const https = HTTPS === "true";
       return {


### PR DESCRIPTION
Merges into #248.

* Refactors to use promise instead of global `Motoko` variable
* Reintroduces `global` definition in Vite config to fix compilation error in dev server (unrelated to the above change)
