### PR TITLE
chore: upgrade to dfx 0.24.2

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
     env:
-      DFX_VERSION: 0.22.0
+      DFX_VERSION: 0.24.2
       IC_REPL_VERSION: 0.7.5
       MOPS_VERSION: 0.2.0
     steps:

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -21,7 +21,7 @@ jobs:
           - 18
           - 20
     env:
-      DFX_VERSION: 0.22.0
+      DFX_VERSION: 0.24.2
       SKIP_WASM: true
       MOPS_VERSION: 0.2.0
     steps:


### PR DESCRIPTION
Fixes build errors of this form:
```
[wasm-validator error in function core::num::flt2dec::strategy::dragon::format_shortest::h7a00140acf4ed238] unexpected false: Bulk memory operations require bulk memory [--enable-bulk-memory], on 
(memory.fill
 (i32.add
  (local.get $4)
  (i32.const 8)
 )
 (i32.const 0)
 (i32.const 152)
)
```