### PR TITLE
fix: Use lower case for Wasm persistence modes

### DIFF
--- a/service/pool/IC.mo
+++ b/service/pool/IC.mo
@@ -23,8 +23,8 @@ module {
     #reinstall;
     #upgrade : ?{
       wasm_memory_persistence : ?{
-          #Keep;
-          #Replace;
+          #keep;
+          #replace;
       };
     };
     #install;


### PR DESCRIPTION
Related to https://github.com/dfinity/ic/pull/3479.
Should only be merged and released together with the corresponding changes to IC.

This changes the variant names for the Wasm memory persistence modes used for Motoko's enhanced orthogonal persistence to lower case to align it with the IC specification, i.e. using `keep` and `replace` instead of `Keep` and `Replace`.

https://dashboard.internetcomputer.org/proposal/135019 has https://github.com/dfinity/ic/pull/3479
