### PR TITLE
chore: script for bumping `moc`

### DIFF
--- a/script/bump-moc.sh
+++ b/script/bump-moc.sh
@@ -12,4 +12,4 @@ curl -L https://github.com/dfinity/motoko/releases/download/${MOC_VERSION}/moc-$
 
 git add src/App.tsx public/moc.js
 git status -uno
-git diff --staged
+git diff --staged src/App.tsx

--- a/script/bump-moc.sh
+++ b/script/bump-moc.sh
@@ -11,4 +11,5 @@ curl -L https://github.com/dfinity/motoko/releases/download/${MOC_VERSION}/moc-$
   > public/moc.js
 
 git add src/App.tsx public/moc.js
-
+git status -uno
+git diff --staged

--- a/script/bump-moc.sh
+++ b/script/bump-moc.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+MOC_VERSION=$1
+
+echo upgrading '`moc`' to $MOC_VERSION
+echo
+
+perl -pi -e "s/MOC_VERSION = \"[0-9\.]+\"/MOC_VERSION = \"$MOC_VERSION\"/g" src/App.tsx
+
+curl -L https://github.com/dfinity/motoko/releases/download/${MOC_VERSION}/moc-${MOC_VERSION}.js \
+  > public/moc.js
+
+git add src/App.tsx public/moc.js
+


### PR DESCRIPTION
## usage: `bash script/bump-moc.sh 0.13.6`

This is very basic for now, we can get fancier as we use it, e.g.
- at start: `git switch main && git pull`
- `git switch -c bump/moc-$MOC_VERSION`
- git commit -m 'chore: bump `moc` to v'$MOC_VERSION
- push it: `git push -u origin bump/moc-$MOC_VERSION`
- make the PR: `open https://github.com/dfinity/motoko-playground/pull/new/bump/moc-$MOC_VERSION`

### example
<img width="657" alt="Screenshot 2025-01-30 at 01 22 26" src="https://github.com/user-attachments/assets/8bd46767-2cb4-42af-b322-eb049d021c7d" />
