### PR TITLE
Update Motoko formatter

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
         "@xterm/xterm": "^5.5.0",
         "lodash.debounce": "^4.0.8",
         "motoko": "^3.10.1",
-        "prettier-plugin-motoko": "^0.9.4",
+        "prettier-plugin-motoko": "^0.10.4",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "react-google-charts": "^4.0.1",
@@ -5717,9 +5717,10 @@
       }
     },
     "node_modules/prettier-plugin-motoko": {
-      "version": "0.9.4",
-      "resolved": "https://registry.npmjs.org/prettier-plugin-motoko/-/prettier-plugin-motoko-0.9.4.tgz",
-      "integrity": "sha512-Nntd7tolzGx9DV6Nu37b+Ys8PO4pPR1ZuijjSJFizmriCvkpTwDspTWB3IBhHkoKLv837NDkx5CmJS4E3F9GzA==",
+      "version": "0.10.4",
+      "resolved": "https://registry.npmjs.org/prettier-plugin-motoko/-/prettier-plugin-motoko-0.10.4.tgz",
+      "integrity": "sha512-SPx2a4w6gIP1gXFjyIHs+SmscOHlEi88pAb+9XVKOlCeOy1rTXbucWJ/L420atNkf5jRpYqPDGFP1Zx2mv99Fg==",
+      "license": "Apache-2.0",
       "dependencies": {
         "out-of-character": "^1.2.1"
       },

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "@xterm/xterm": "^5.5.0",
     "lodash.debounce": "^4.0.8",
     "motoko": "^3.10.1",
-    "prettier-plugin-motoko": "^0.9.4",
+    "prettier-plugin-motoko": "^0.10.4",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-google-charts": "^4.0.1",


### PR DESCRIPTION
Propagates changes from https://github.com/dfinity/prettier-plugin-motoko/pull/154.

Note that a redeploy will not be necessary. This is for syntax introduced in the next version of Motoko, which we will update in a separate PR.