### PR TITLE
chore: avoid composite canister http transform in pool canister

### DIFF
--- a/service/pool/Main.mo
+++ b/service/pool/Main.mo
@@ -717,33 +717,9 @@ shared (creator) actor class Self(opt_params : ?Types.InitParams) = this {
     };
     public shared ({ caller }) func _ttp_request(request : ICType.http_request_args) : async ICType.http_request_result {
         await* pool.addCycles(caller, #method "http_request");
-        let new_request = switch (request.transform) {
-        case null {
-                 { request with transform = null };
-             };
-        case (?transform) {
-                 let payload = { caller; transform };
-                 let fake_actor: actor { __transform: ICType.transform_function } = actor(Principal.toText(Principal.fromActor this));
-                 let new_transform = ?{ function = fake_actor.__transform; context = to_candid(payload) };
-                 { request with transform = new_transform };
-             };
-        };
-        let res = await IC.http_request(new_request);
+        let res = await IC.http_request(request);
         await* pool.addCycles(caller, #refund);
         res;
-    };
-    public shared composite query({ caller }) func __transform({context: Blob; response: ICType.http_request_result}) : async ICType.http_request_result {
-        // TODO Remove anonymous identity once https://github.com/dfinity/ic/pull/1337 is released
-        if (caller != Principal.fromText("aaaaa-aa") and caller != Principal.fromText("2vxsx-fae")) {
-            throw Error.reject "Only the management canister can call __transform";
-        };
-        let ?raw : ?{ caller: Principal; transform: {context: Blob; function: ICType.transform_function} } = from_candid context else {
-            throw Error.reject "__transform: Invalid context";
-        };
-        if (not pool.findId(raw.caller)) {
-            throw Error.reject "__transform: Only a canister managed by the Motoko Playground can call __transform";
-        };
-        await raw.transform.function({ context = raw.transform.context; response });
     };
     // Endpoints for EVM RPC canister
     public shared ({ caller }) func eth_call(service: EVM.RpcServices, config: ?EVM.RpcConfig, arg: EVM.CallArgs) : async EVM.MultiCallResult {
@@ -835,7 +811,6 @@ shared (creator) actor class Self(opt_params : ?Types.InitParams) = this {
             #delete_canister_snapshot : Any;
             #load_canister_snapshot : Any;
             #_ttp_request : Any;
-            #__transform : Any;
             #sign_with_ecdsa: Any;
             #sign_with_schnorr: Any;
             #eth_call: Any;
@@ -860,7 +835,6 @@ shared (creator) actor class Self(opt_params : ?Types.InitParams) = this {
             case (#delete_canister_snapshot _) false;
             case (#load_canister_snapshot _) false;
             case (#_ttp_request _) false;
-            case (#__transform _) false;
             case (#sign_with_ecdsa _) false;
             case (#sign_with_schnorr _) false;
             case (#eth_call _) false;

--- a/src/declarations/backend/backend.did
+++ b/src/declarations/backend/backend.did
@@ -11,6 +11,33 @@ type snapshot =
    taken_at_timestamp: nat64;
    total_size: nat64;
  };
+type sign_with_schnorr_result = record {signature: blob;};
+type sign_with_schnorr_args = 
+ record {
+   aux: opt schnorr_aux;
+   derivation_path: vec blob;
+   key_id: record {
+             algorithm: schnorr_algorithm;
+             name: text;
+           };
+   message: blob;
+ };
+type sign_with_ecdsa_result = record {signature: blob;};
+type sign_with_ecdsa_args = 
+ record {
+   derivation_path: vec blob;
+   key_id: record {
+             curve: ecdsa_curve;
+             name: text;
+           };
+   message_hash: blob;
+ };
+type schnorr_aux = variant {bip341: record {merkle_root_hash: blob;};};
+type schnorr_algorithm = 
+ variant {
+   bip340secp256k1;
+   ed25519;
+ };
 type log_visibility = 
  variant {
    controllers;
@@ -43,6 +70,7 @@ type http_header =
    name: text;
    value: text;
  };
+type ecdsa_curve = variant {secp256k1;};
 type definite_canister_settings = 
  record {
    compute_allocation: nat;
@@ -82,7 +110,57 @@ type canister_settings =
    memory_allocation: opt nat;
    wasm_memory_limit: opt nat;
  };
+type canister_install_mode = 
+ variant {
+   install;
+   reinstall;
+   upgrade:
+    opt record {wasm_memory_persistence: opt variant {
+                                               keep;
+                                               replace;
+                                             };};
+ };
 type canister_id = principal;
+type ValidationError = 
+ variant {
+   Custom: text;
+   InvalidHex: text;
+ };
+type TransactionRequest = 
+ record {
+   accessList: opt vec AccessListEntry;
+   blobVersionedHashes: opt vec text;
+   blobs: opt vec text;
+   chainId: opt nat;
+   from: opt text;
+   gas: opt nat;
+   gasPrice: opt nat;
+   input: opt text;
+   maxFeePerBlobGas: opt nat;
+   maxFeePerGas: opt nat;
+   maxPriorityFeePerGas: opt nat;
+   nonce: opt nat;
+   to: opt text;
+   "type": opt text;
+   value: opt nat;
+ };
+type TransactionReceipt = 
+ record {
+   blockHash: text;
+   blockNumber: nat;
+   contractAddress: opt text;
+   effectiveGasPrice: nat;
+   from: text;
+   gasUsed: nat;
+   logs: vec LogEntry;
+   logsBloom: text;
+   status: opt nat;
+   to: opt text;
+   transactionHash: text;
+   transactionIndex: nat;
+   "type": text;
+ };
+type Topic = vec text;
 type Stats = 
  record {
    cycles_used: nat;
@@ -92,13 +170,21 @@ type Stats =
    num_of_canisters: nat;
    num_of_installs: nat;
  };
+type SendRawTransactionStatus = 
+ variant {
+   InsufficientFunds;
+   NonceTooHigh;
+   NonceTooLow;
+   Ok: opt text;
+ };
+type SendRawTransactionResult = 
+ variant {
+   Err: RpcError;
+   Ok: SendRawTransactionStatus;
+ };
 type Self = 
  service {
    GCCanisters: () -> () oneway;
-   __transform: (record {
-                   context: blob;
-                   response: http_request_result;
-                 }) -> (http_request_result) composite_query;
    _ttp_request: (http_request_args) -> (http_request_result);
    balance: () -> (nat) query;
    callForward: (CanisterInfo, text, blob) -> (blob);
@@ -114,12 +200,21 @@ type Self =
        snapshot_id: blob;
      }) -> ();
    deployCanister: (opt CanisterInfo, opt DeployArgs) -> (CanisterInfo,
-    variant {
-      install;
-      reinstall;
-      upgrade;
-    });
+    canister_install_mode);
    dump: () -> (vec CanisterInfo) query;
+   eth_call: (RpcServices, opt RpcConfig, CallArgs) -> (MultiCallResult);
+   eth_feeHistory: (RpcServices, opt RpcConfig, FeeHistoryArgs) ->
+    (MultiFeeHistoryResult);
+   eth_getBlockByNumber: (RpcServices, opt RpcConfig, BlockTag) ->
+    (MultiGetBlockByNumberResult);
+   eth_getLogs: (RpcServices, opt RpcConfig, GetLogsArgs) ->
+    (MultiGetLogsResult);
+   eth_getTransactionCount: (RpcServices, opt RpcConfig,
+    GetTransactionCountArgs) -> (MultiGetTransactionCountResult);
+   eth_getTransactionReceipt: (RpcServices, opt RpcConfig, text) ->
+    (MultiGetTransactionReceiptResult);
+   eth_sendRawTransaction: (RpcServices, opt RpcConfig, text) ->
+    (MultiSendRawTransactionResult);
    getCanisterId: (Nonce, Origin) -> (CanisterInfo);
    getInitParams: () -> (InitParams) query;
    getStats: () -> (Stats, vec record {
@@ -142,11 +237,7 @@ type Self =
     (record {
        arg: blob;
        canister_id: canister_id;
-       mode: variant {
-               install;
-               reinstall;
-               upgrade;
-             };
+       mode: canister_install_mode;
        wasm_module: wasm_module;
      }) -> ();
    listSnapshots: (CanisterInfo) -> (vec snapshot);
@@ -157,7 +248,10 @@ type Self =
    mergeTags: (text, opt text) -> ();
    releaseAllCanisters: () -> ();
    removeCode: (CanisterInfo) -> ();
+   request: (RpcService, text, nat64) -> (RequestResult);
    resetStats: () -> ();
+   sign_with_ecdsa: (sign_with_ecdsa_args) -> (sign_with_ecdsa_result);
+   sign_with_schnorr: (sign_with_schnorr_args) -> (sign_with_schnorr_result);
    start_canister: (record {canister_id: canister_id;}) -> ();
    stop_canister: (record {canister_id: canister_id;}) -> ();
    takeSnapshot: (CanisterInfo) -> (opt blob);
@@ -175,6 +269,72 @@ type Self =
      }) -> ();
    wallet_receive: () -> ();
  };
+type RpcServices = 
+ variant {
+   ArbitrumOne: opt vec L2MainnetService;
+   BaseMainnet: opt vec L2MainnetService;
+   Custom: record {
+             chainId: ChainId;
+             services: vec RpcApi;
+           };
+   EthMainnet: opt vec EthMainnetService;
+   EthSepolia: opt vec EthSepoliaService;
+   OptimismMainnet: opt vec L2MainnetService;
+ };
+type RpcService = 
+ variant {
+   ArbitrumOne: L2MainnetService;
+   BaseMainnet: L2MainnetService;
+   Custom: RpcApi;
+   EthMainnet: EthMainnetService;
+   EthSepolia: EthSepoliaService;
+   OptimismMainnet: L2MainnetService;
+   Provider: ProviderId;
+ };
+type RpcError = 
+ variant {
+   HttpOutcallError: HttpOutcallError;
+   JsonRpcError: JsonRpcError;
+   ProviderError: ProviderError;
+   ValidationError: ValidationError;
+ };
+type RpcConfig = 
+ record {
+   responseConsensus: opt ConsensusStrategy;
+   responseSizeEstimate: opt nat64;
+ };
+type RpcApi = 
+ record {
+   headers: opt vec HttpHeader;
+   url: text;
+ };
+type RequestResult = 
+ variant {
+   Err: RpcError;
+   Ok: text;
+ };
+type RejectionCode = 
+ variant {
+   CanisterError;
+   CanisterReject;
+   DestinationInvalid;
+   NoError;
+   SysFatal;
+   SysTransient;
+   Unknown;
+ };
+type ProviderId = nat64;
+type ProviderError = 
+ variant {
+   InvalidRpcConfig: text;
+   MissingRequiredProvider;
+   NoPermission;
+   ProviderNotFound;
+   TooFewCycles: record {
+                   expected: nat;
+                   received: nat;
+                 };
+ };
 type Origin = 
  record {
    origin: text;
@@ -184,6 +344,87 @@ type Nonce =
  record {
    nonce: nat;
    timestamp: int;
+ };
+type MultiSendRawTransactionResult = 
+ variant {
+   Consistent: SendRawTransactionResult;
+   Inconsistent: vec record {
+                       RpcService;
+                       SendRawTransactionResult;
+                     };
+ };
+type MultiGetTransactionReceiptResult = 
+ variant {
+   Consistent: GetTransactionReceiptResult;
+   Inconsistent: vec record {
+                       RpcService;
+                       GetTransactionReceiptResult;
+                     };
+ };
+type MultiGetTransactionCountResult = 
+ variant {
+   Consistent: GetTransactionCountResult;
+   Inconsistent: vec record {
+                       RpcService;
+                       GetTransactionCountResult;
+                     };
+ };
+type MultiGetLogsResult = 
+ variant {
+   Consistent: GetLogsResult;
+   Inconsistent: vec record {
+                       RpcService;
+                       GetLogsResult;
+                     };
+ };
+type MultiGetBlockByNumberResult = 
+ variant {
+   Consistent: GetBlockByNumberResult;
+   Inconsistent: vec record {
+                       RpcService;
+                       GetBlockByNumberResult;
+                     };
+ };
+type MultiFeeHistoryResult = 
+ variant {
+   Consistent: FeeHistoryResult;
+   Inconsistent: vec record {
+                       RpcService;
+                       FeeHistoryResult;
+                     };
+ };
+type MultiCallResult = 
+ variant {
+   Consistent: CallResult;
+   Inconsistent: vec record {
+                       RpcService;
+                       CallResult;
+                     };
+ };
+type LogEntry = 
+ record {
+   address: text;
+   blockHash: opt text;
+   blockNumber: opt nat;
+   data: text;
+   logIndex: opt nat;
+   removed: bool;
+   topics: vec text;
+   transactionHash: opt text;
+   transactionIndex: opt nat;
+ };
+type L2MainnetService = 
+ variant {
+   Alchemy;
+   Ankr;
+   BlockPi;
+   Llama;
+   PublicNode;
+ };
+type JsonRpcError = 
+ record {
+   code: int64;
+   message: text;
  };
 type InstallConfig = 
  record {
@@ -200,11 +441,7 @@ type InstallArgs =
  record {
    arg: blob;
    canister_id: principal;
-   mode: variant {
-           install;
-           reinstall;
-           upgrade;
-         };
+   mode: canister_install_mode;
    wasm_module: blob;
  };
 type InitParams = 
@@ -212,6 +449,7 @@ type InitParams =
    admin_only: opt bool;
    canister_time_to_live: nat;
    cycles_per_canister: nat;
+   cycles_settings: opt CyclesSettings;
    max_family_tree_size: nat;
    max_num_canisters: nat;
    nonce_time_to_live: nat;
@@ -240,15 +478,163 @@ type HttpRequest =
    method: text;
    url: text;
  };
+type HttpOutcallError = 
+ variant {
+   IcError: record {
+              code: RejectionCode;
+              message: text;
+            };
+   InvalidHttpJsonRpcResponse:
+    record {
+      body: text;
+      parsingError: opt text;
+      status: nat16;
+    };
+ };
+type HttpHeader = 
+ record {
+   name: text;
+   value: text;
+ };
+type GetTransactionReceiptResult = 
+ variant {
+   Err: RpcError;
+   Ok: opt TransactionReceipt;
+ };
+type GetTransactionCountResult = 
+ variant {
+   Err: RpcError;
+   Ok: nat;
+ };
+type GetTransactionCountArgs = 
+ record {
+   address: text;
+   block: BlockTag;
+ };
+type GetLogsResult = 
+ variant {
+   Err: RpcError;
+   Ok: vec LogEntry;
+ };
+type GetLogsArgs = 
+ record {
+   addresses: vec text;
+   fromBlock: opt BlockTag;
+   toBlock: opt BlockTag;
+   topics: opt vec Topic;
+ };
+type GetBlockByNumberResult = 
+ variant {
+   Err: RpcError;
+   Ok: Block;
+ };
+type FeeHistoryResult = 
+ variant {
+   Err: RpcError;
+   Ok: FeeHistory;
+ };
+type FeeHistoryArgs = 
+ record {
+   blockCount: nat;
+   newestBlock: BlockTag;
+   rewardPercentiles: opt blob;
+ };
+type FeeHistory = 
+ record {
+   baseFeePerGas: vec nat;
+   gasUsedRatio: vec float64;
+   oldestBlock: nat;
+   reward: vec vec nat;
+ };
+type EthSepoliaService = 
+ variant {
+   Alchemy;
+   Ankr;
+   BlockPi;
+   PublicNode;
+   Sepolia;
+ };
+type EthMainnetService = 
+ variant {
+   Alchemy;
+   Ankr;
+   BlockPi;
+   Cloudflare;
+   Llama;
+   PublicNode;
+ };
 type DeployArgs = 
  record {
    arg: blob;
    bypass_wasm_transform: opt bool;
+   mode: opt canister_install_mode;
    wasm_module: blob;
  };
+type CyclesSettings = 
+ record {
+   max_cycles_per_call: nat;
+   max_cycles_total: nat;
+ };
+type ConsensusStrategy = 
+ variant {
+   Equality;
+   Threshold: record {
+                min: nat8;
+                total: opt nat8;
+              };
+ };
+type ChainId = nat64;
 type CanisterInfo = 
  record {
    id: principal;
    timestamp: int;
+ };
+type CallResult = 
+ variant {
+   Err: RpcError;
+   Ok: text;
+ };
+type CallArgs = 
+ record {
+   block: opt BlockTag;
+   transaction: TransactionRequest;
+ };
+type BlockTag = 
+ variant {
+   Earliest;
+   Finalized;
+   Latest;
+   Number: nat;
+   Pending;
+   Safe;
+ };
+type Block = 
+ record {
+   baseFeePerGas: opt nat;
+   difficulty: opt nat;
+   extraData: text;
+   gasLimit: nat;
+   gasUsed: nat;
+   hash: text;
+   logsBloom: text;
+   miner: text;
+   mixHash: text;
+   nonce: nat;
+   number: nat;
+   parentHash: text;
+   receiptsRoot: text;
+   sha3Uncles: text;
+   size: nat;
+   stateRoot: text;
+   timestamp: nat;
+   totalDifficulty: opt nat;
+   transactions: vec text;
+   transactionsRoot: opt text;
+   uncles: vec text;
+ };
+type AccessListEntry = 
+ record {
+   address: text;
+   storageKeys: vec text;
  };
 service : (opt InitParams) -> Self

--- a/src/declarations/backend/backend.did.d.ts
+++ b/src/declarations/backend/backend.did.d.ts
@@ -2,15 +2,119 @@ import type { Principal } from "@dfinity/principal";
 import type { ActorMethod } from "@dfinity/agent";
 import type { IDL } from "@dfinity/candid";
 
+export interface AccessListEntry {
+  storageKeys: Array<string>;
+  address: string;
+}
+export interface Block {
+  miner: string;
+  totalDifficulty: [] | [bigint];
+  receiptsRoot: string;
+  stateRoot: string;
+  hash: string;
+  difficulty: [] | [bigint];
+  size: bigint;
+  uncles: Array<string>;
+  baseFeePerGas: [] | [bigint];
+  extraData: string;
+  transactionsRoot: [] | [string];
+  sha3Uncles: string;
+  nonce: bigint;
+  number: bigint;
+  timestamp: bigint;
+  transactions: Array<string>;
+  gasLimit: bigint;
+  logsBloom: string;
+  parentHash: string;
+  gasUsed: bigint;
+  mixHash: string;
+}
+export type BlockTag =
+  | { Earliest: null }
+  | { Safe: null }
+  | { Finalized: null }
+  | { Latest: null }
+  | { Number: bigint }
+  | { Pending: null };
+export interface CallArgs {
+  transaction: TransactionRequest;
+  block: [] | [BlockTag];
+}
+export type CallResult = { Ok: string } | { Err: RpcError };
 export interface CanisterInfo {
   id: Principal;
   timestamp: bigint;
+}
+export type ChainId = bigint;
+export type ConsensusStrategy =
+  | { Equality: null }
+  | { Threshold: { min: number; total: [] | [number] } };
+export interface CyclesSettings {
+  max_cycles_per_call: bigint;
+  max_cycles_total: bigint;
 }
 export interface DeployArgs {
   arg: Uint8Array | number[];
   wasm_module: Uint8Array | number[];
   bypass_wasm_transform: [] | [boolean];
+  mode: [] | [canister_install_mode];
 }
+export type EthMainnetService =
+  | { Alchemy: null }
+  | { Llama: null }
+  | { BlockPi: null }
+  | { Cloudflare: null }
+  | { PublicNode: null }
+  | { Ankr: null };
+export type EthSepoliaService =
+  | { Alchemy: null }
+  | { BlockPi: null }
+  | { PublicNode: null }
+  | { Ankr: null }
+  | { Sepolia: null };
+export interface FeeHistory {
+  reward: Array<Array<bigint>>;
+  gasUsedRatio: Array<number>;
+  oldestBlock: bigint;
+  baseFeePerGas: Array<bigint>;
+}
+export interface FeeHistoryArgs {
+  blockCount: bigint;
+  newestBlock: BlockTag;
+  rewardPercentiles: [] | [Uint8Array | number[]];
+}
+export type FeeHistoryResult = { Ok: FeeHistory } | { Err: RpcError };
+export type GetBlockByNumberResult = { Ok: Block } | { Err: RpcError };
+export interface GetLogsArgs {
+  fromBlock: [] | [BlockTag];
+  toBlock: [] | [BlockTag];
+  addresses: Array<string>;
+  topics: [] | [Array<Topic>];
+}
+export type GetLogsResult = { Ok: Array<LogEntry> } | { Err: RpcError };
+export interface GetTransactionCountArgs {
+  address: string;
+  block: BlockTag;
+}
+export type GetTransactionCountResult = { Ok: bigint } | { Err: RpcError };
+export type GetTransactionReceiptResult =
+  | { Ok: [] | [TransactionReceipt] }
+  | { Err: RpcError };
+export interface HttpHeader {
+  value: string;
+  name: string;
+}
+export type HttpOutcallError =
+  | {
+      IcError: { code: RejectionCode; message: string };
+    }
+  | {
+      InvalidHttpJsonRpcResponse: {
+        status: number;
+        body: string;
+        parsingError: [] | [string];
+      };
+    };
 export interface HttpRequest {
   url: string;
   method: string;
@@ -28,6 +132,7 @@ export interface InitParams {
   stored_module:
     | []
     | [{ arg: Uint8Array | number[]; hash: Uint8Array | number[] }];
+  cycles_settings: [] | [CyclesSettings];
   wasm_utils_principal: [] | [string];
   cycles_per_canister: bigint;
   admin_only: [] | [boolean];
@@ -37,7 +142,7 @@ export interface InitParams {
 export interface InstallArgs {
   arg: Uint8Array | number[];
   wasm_module: Uint8Array | number[];
-  mode: { reinstall: null } | { upgrade: null } | { install: null };
+  mode: canister_install_mode;
   canister_id: Principal;
 }
 export interface InstallConfig {
@@ -47,6 +152,56 @@ export interface InstallConfig {
   start_page: [] | [number];
   page_limit: [] | [number];
 }
+export interface JsonRpcError {
+  code: bigint;
+  message: string;
+}
+export type L2MainnetService =
+  | { Alchemy: null }
+  | { Llama: null }
+  | { BlockPi: null }
+  | { PublicNode: null }
+  | { Ankr: null };
+export interface LogEntry {
+  transactionHash: [] | [string];
+  blockNumber: [] | [bigint];
+  data: string;
+  blockHash: [] | [string];
+  transactionIndex: [] | [bigint];
+  topics: Array<string>;
+  address: string;
+  logIndex: [] | [bigint];
+  removed: boolean;
+}
+export type MultiCallResult =
+  | { Consistent: CallResult }
+  | { Inconsistent: Array<[RpcService, CallResult]> };
+export type MultiFeeHistoryResult =
+  | { Consistent: FeeHistoryResult }
+  | { Inconsistent: Array<[RpcService, FeeHistoryResult]> };
+export type MultiGetBlockByNumberResult =
+  | {
+      Consistent: GetBlockByNumberResult;
+    }
+  | { Inconsistent: Array<[RpcService, GetBlockByNumberResult]> };
+export type MultiGetLogsResult =
+  | { Consistent: GetLogsResult }
+  | { Inconsistent: Array<[RpcService, GetLogsResult]> };
+export type MultiGetTransactionCountResult =
+  | {
+      Consistent: GetTransactionCountResult;
+    }
+  | { Inconsistent: Array<[RpcService, GetTransactionCountResult]> };
+export type MultiGetTransactionReceiptResult =
+  | {
+      Consistent: GetTransactionReceiptResult;
+    }
+  | { Inconsistent: Array<[RpcService, GetTransactionReceiptResult]> };
+export type MultiSendRawTransactionResult =
+  | {
+      Consistent: SendRawTransactionResult;
+    }
+  | { Inconsistent: Array<[RpcService, SendRawTransactionResult]> };
 export interface Nonce {
   nonce: bigint;
   timestamp: bigint;
@@ -55,12 +210,54 @@ export interface Origin {
   origin: string;
   tags: Array<string>;
 }
+export type ProviderError =
+  | {
+      TooFewCycles: { expected: bigint; received: bigint };
+    }
+  | { InvalidRpcConfig: string }
+  | { MissingRequiredProvider: null }
+  | { ProviderNotFound: null }
+  | { NoPermission: null };
+export type ProviderId = bigint;
+export type RejectionCode =
+  | { NoError: null }
+  | { CanisterError: null }
+  | { SysTransient: null }
+  | { DestinationInvalid: null }
+  | { Unknown: null }
+  | { SysFatal: null }
+  | { CanisterReject: null };
+export type RequestResult = { Ok: string } | { Err: RpcError };
+export interface RpcApi {
+  url: string;
+  headers: [] | [Array<HttpHeader>];
+}
+export interface RpcConfig {
+  responseConsensus: [] | [ConsensusStrategy];
+  responseSizeEstimate: [] | [bigint];
+}
+export type RpcError =
+  | { JsonRpcError: JsonRpcError }
+  | { ProviderError: ProviderError }
+  | { ValidationError: ValidationError }
+  | { HttpOutcallError: HttpOutcallError };
+export type RpcService =
+  | { EthSepolia: EthSepoliaService }
+  | { BaseMainnet: L2MainnetService }
+  | { Custom: RpcApi }
+  | { OptimismMainnet: L2MainnetService }
+  | { ArbitrumOne: L2MainnetService }
+  | { EthMainnet: EthMainnetService }
+  | { Provider: ProviderId };
+export type RpcServices =
+  | { EthSepolia: [] | [Array<EthSepoliaService>] }
+  | { BaseMainnet: [] | [Array<L2MainnetService>] }
+  | { Custom: { chainId: ChainId; services: Array<RpcApi> } }
+  | { OptimismMainnet: [] | [Array<L2MainnetService>] }
+  | { ArbitrumOne: [] | [Array<L2MainnetService>] }
+  | { EthMainnet: [] | [Array<EthMainnetService>] };
 export interface Self {
   GCCanisters: ActorMethod<[], undefined>;
-  __transform: ActorMethod<
-    [{ context: Uint8Array | number[]; response: http_request_result }],
-    http_request_result
-  >;
   _ttp_request: ActorMethod<[http_request_args], http_request_result>;
   balance: ActorMethod<[], bigint>;
   callForward: ActorMethod<
@@ -83,9 +280,37 @@ export interface Self {
   >;
   deployCanister: ActorMethod<
     [[] | [CanisterInfo], [] | [DeployArgs]],
-    [CanisterInfo, { reinstall: null } | { upgrade: null } | { install: null }]
+    [CanisterInfo, canister_install_mode]
   >;
   dump: ActorMethod<[], Array<CanisterInfo>>;
+  eth_call: ActorMethod<
+    [RpcServices, [] | [RpcConfig], CallArgs],
+    MultiCallResult
+  >;
+  eth_feeHistory: ActorMethod<
+    [RpcServices, [] | [RpcConfig], FeeHistoryArgs],
+    MultiFeeHistoryResult
+  >;
+  eth_getBlockByNumber: ActorMethod<
+    [RpcServices, [] | [RpcConfig], BlockTag],
+    MultiGetBlockByNumberResult
+  >;
+  eth_getLogs: ActorMethod<
+    [RpcServices, [] | [RpcConfig], GetLogsArgs],
+    MultiGetLogsResult
+  >;
+  eth_getTransactionCount: ActorMethod<
+    [RpcServices, [] | [RpcConfig], GetTransactionCountArgs],
+    MultiGetTransactionCountResult
+  >;
+  eth_getTransactionReceipt: ActorMethod<
+    [RpcServices, [] | [RpcConfig], string],
+    MultiGetTransactionReceiptResult
+  >;
+  eth_sendRawTransaction: ActorMethod<
+    [RpcServices, [] | [RpcConfig], string],
+    MultiSendRawTransactionResult
+  >;
   getCanisterId: ActorMethod<[Nonce, Origin], CanisterInfo>;
   getInitParams: ActorMethod<[], InitParams>;
   getStats: ActorMethod<
@@ -111,7 +336,7 @@ export interface Self {
       {
         arg: Uint8Array | number[];
         wasm_module: wasm_module;
-        mode: { reinstall: null } | { upgrade: null } | { install: null };
+        mode: canister_install_mode;
         canister_id: canister_id;
       },
     ],
@@ -127,7 +352,13 @@ export interface Self {
   mergeTags: ActorMethod<[string, [] | [string]], undefined>;
   releaseAllCanisters: ActorMethod<[], undefined>;
   removeCode: ActorMethod<[CanisterInfo], undefined>;
+  request: ActorMethod<[RpcService, string, bigint], RequestResult>;
   resetStats: ActorMethod<[], undefined>;
+  sign_with_ecdsa: ActorMethod<[sign_with_ecdsa_args], sign_with_ecdsa_result>;
+  sign_with_schnorr: ActorMethod<
+    [sign_with_schnorr_args],
+    sign_with_schnorr_result
+  >;
   start_canister: ActorMethod<[{ canister_id: canister_id }], undefined>;
   stop_canister: ActorMethod<[{ canister_id: canister_id }], undefined>;
   takeSnapshot: ActorMethod<[CanisterInfo], [] | [Uint8Array | number[]]>;
@@ -148,6 +379,14 @@ export interface Self {
   >;
   wallet_receive: ActorMethod<[], undefined>;
 }
+export type SendRawTransactionResult =
+  | { Ok: SendRawTransactionStatus }
+  | { Err: RpcError };
+export type SendRawTransactionStatus =
+  | { Ok: [] | [string] }
+  | { NonceTooLow: null }
+  | { NonceTooHigh: null }
+  | { InsufficientFunds: null };
 export interface Stats {
   num_of_installs: bigint;
   num_of_canisters: bigint;
@@ -156,7 +395,55 @@ export interface Stats {
   cycles_used: bigint;
   error_total_wait_time: bigint;
 }
+export type Topic = Array<string>;
+export interface TransactionReceipt {
+  to: [] | [string];
+  status: [] | [bigint];
+  transactionHash: string;
+  blockNumber: bigint;
+  from: string;
+  logs: Array<LogEntry>;
+  blockHash: string;
+  type: string;
+  transactionIndex: bigint;
+  effectiveGasPrice: bigint;
+  logsBloom: string;
+  contractAddress: [] | [string];
+  gasUsed: bigint;
+}
+export interface TransactionRequest {
+  to: [] | [string];
+  gas: [] | [bigint];
+  maxFeePerGas: [] | [bigint];
+  gasPrice: [] | [bigint];
+  value: [] | [bigint];
+  maxFeePerBlobGas: [] | [bigint];
+  from: [] | [string];
+  type: [] | [string];
+  accessList: [] | [Array<AccessListEntry>];
+  nonce: [] | [bigint];
+  maxPriorityFeePerGas: [] | [bigint];
+  blobs: [] | [Array<string>];
+  input: [] | [string];
+  chainId: [] | [bigint];
+  blobVersionedHashes: [] | [Array<string>];
+}
+export type ValidationError = { Custom: string } | { InvalidHex: string };
 export type canister_id = Principal;
+export type canister_install_mode =
+  | { reinstall: null }
+  | {
+      upgrade:
+        | []
+        | [
+            {
+              wasm_memory_persistence:
+                | []
+                | [{ keep: null } | { replace: null }];
+            },
+          ];
+    }
+  | { install: null };
 export interface canister_settings {
   freezing_threshold: [] | [bigint];
   controllers: [] | [Array<Principal>];
@@ -188,6 +475,7 @@ export interface definite_canister_settings {
   memory_allocation: bigint;
   compute_allocation: bigint;
 }
+export type ecdsa_curve = { secp256k1: null };
 export interface http_header {
   value: string;
   name: string;
@@ -208,6 +496,27 @@ export interface http_request_result {
   headers: Array<http_header>;
 }
 export type log_visibility = { controllers: null } | { public: null };
+export type schnorr_algorithm = { ed25519: null } | { bip340secp256k1: null };
+export type schnorr_aux = {
+  bip341: { merkle_root_hash: Uint8Array | number[] };
+};
+export interface sign_with_ecdsa_args {
+  key_id: { name: string; curve: ecdsa_curve };
+  derivation_path: Array<Uint8Array | number[]>;
+  message_hash: Uint8Array | number[];
+}
+export interface sign_with_ecdsa_result {
+  signature: Uint8Array | number[];
+}
+export interface sign_with_schnorr_args {
+  aux: [] | [schnorr_aux];
+  key_id: { algorithm: schnorr_algorithm; name: string };
+  derivation_path: Array<Uint8Array | number[]>;
+  message: Uint8Array | number[];
+}
+export interface sign_with_schnorr_result {
+  signature: Uint8Array | number[];
+}
 export interface snapshot {
   id: snapshot_id;
   total_size: bigint;

--- a/src/declarations/backend/backend.did.js
+++ b/src/declarations/backend/backend.did.js
@@ -1,10 +1,15 @@
 export const idlFactory = ({ IDL }) => {
+  const CyclesSettings = IDL.Record({
+    max_cycles_per_call: IDL.Nat,
+    max_cycles_total: IDL.Nat,
+  });
   const InitParams = IDL.Record({
     max_num_canisters: IDL.Nat,
     canister_time_to_live: IDL.Nat,
     stored_module: IDL.Opt(
       IDL.Record({ arg: IDL.Vec(IDL.Nat8), hash: IDL.Vec(IDL.Nat8) }),
     ),
+    cycles_settings: IDL.Opt(CyclesSettings),
     wasm_utils_principal: IDL.Opt(IDL.Text),
     cycles_per_canister: IDL.Nat,
     admin_only: IDL.Opt(IDL.Bool),
@@ -88,10 +93,274 @@ export const idlFactory = ({ IDL }) => {
     memory_allocation: IDL.Opt(IDL.Nat),
     compute_allocation: IDL.Opt(IDL.Nat),
   });
+  const canister_install_mode = IDL.Variant({
+    reinstall: IDL.Null,
+    upgrade: IDL.Opt(
+      IDL.Record({
+        wasm_memory_persistence: IDL.Opt(
+          IDL.Variant({ keep: IDL.Null, replace: IDL.Null }),
+        ),
+      }),
+    ),
+    install: IDL.Null,
+  });
   const DeployArgs = IDL.Record({
     arg: IDL.Vec(IDL.Nat8),
     wasm_module: IDL.Vec(IDL.Nat8),
     bypass_wasm_transform: IDL.Opt(IDL.Bool),
+    mode: IDL.Opt(canister_install_mode),
+  });
+  const EthSepoliaService = IDL.Variant({
+    Alchemy: IDL.Null,
+    BlockPi: IDL.Null,
+    PublicNode: IDL.Null,
+    Ankr: IDL.Null,
+    Sepolia: IDL.Null,
+  });
+  const L2MainnetService = IDL.Variant({
+    Alchemy: IDL.Null,
+    Llama: IDL.Null,
+    BlockPi: IDL.Null,
+    PublicNode: IDL.Null,
+    Ankr: IDL.Null,
+  });
+  const ChainId = IDL.Nat64;
+  const HttpHeader = IDL.Record({ value: IDL.Text, name: IDL.Text });
+  const RpcApi = IDL.Record({
+    url: IDL.Text,
+    headers: IDL.Opt(IDL.Vec(HttpHeader)),
+  });
+  const EthMainnetService = IDL.Variant({
+    Alchemy: IDL.Null,
+    Llama: IDL.Null,
+    BlockPi: IDL.Null,
+    Cloudflare: IDL.Null,
+    PublicNode: IDL.Null,
+    Ankr: IDL.Null,
+  });
+  const RpcServices = IDL.Variant({
+    EthSepolia: IDL.Opt(IDL.Vec(EthSepoliaService)),
+    BaseMainnet: IDL.Opt(IDL.Vec(L2MainnetService)),
+    Custom: IDL.Record({
+      chainId: ChainId,
+      services: IDL.Vec(RpcApi),
+    }),
+    OptimismMainnet: IDL.Opt(IDL.Vec(L2MainnetService)),
+    ArbitrumOne: IDL.Opt(IDL.Vec(L2MainnetService)),
+    EthMainnet: IDL.Opt(IDL.Vec(EthMainnetService)),
+  });
+  const ConsensusStrategy = IDL.Variant({
+    Equality: IDL.Null,
+    Threshold: IDL.Record({ min: IDL.Nat8, total: IDL.Opt(IDL.Nat8) }),
+  });
+  const RpcConfig = IDL.Record({
+    responseConsensus: IDL.Opt(ConsensusStrategy),
+    responseSizeEstimate: IDL.Opt(IDL.Nat64),
+  });
+  const AccessListEntry = IDL.Record({
+    storageKeys: IDL.Vec(IDL.Text),
+    address: IDL.Text,
+  });
+  const TransactionRequest = IDL.Record({
+    to: IDL.Opt(IDL.Text),
+    gas: IDL.Opt(IDL.Nat),
+    maxFeePerGas: IDL.Opt(IDL.Nat),
+    gasPrice: IDL.Opt(IDL.Nat),
+    value: IDL.Opt(IDL.Nat),
+    maxFeePerBlobGas: IDL.Opt(IDL.Nat),
+    from: IDL.Opt(IDL.Text),
+    type: IDL.Opt(IDL.Text),
+    accessList: IDL.Opt(IDL.Vec(AccessListEntry)),
+    nonce: IDL.Opt(IDL.Nat),
+    maxPriorityFeePerGas: IDL.Opt(IDL.Nat),
+    blobs: IDL.Opt(IDL.Vec(IDL.Text)),
+    input: IDL.Opt(IDL.Text),
+    chainId: IDL.Opt(IDL.Nat),
+    blobVersionedHashes: IDL.Opt(IDL.Vec(IDL.Text)),
+  });
+  const BlockTag = IDL.Variant({
+    Earliest: IDL.Null,
+    Safe: IDL.Null,
+    Finalized: IDL.Null,
+    Latest: IDL.Null,
+    Number: IDL.Nat,
+    Pending: IDL.Null,
+  });
+  const CallArgs = IDL.Record({
+    transaction: TransactionRequest,
+    block: IDL.Opt(BlockTag),
+  });
+  const JsonRpcError = IDL.Record({ code: IDL.Int64, message: IDL.Text });
+  const ProviderError = IDL.Variant({
+    TooFewCycles: IDL.Record({ expected: IDL.Nat, received: IDL.Nat }),
+    InvalidRpcConfig: IDL.Text,
+    MissingRequiredProvider: IDL.Null,
+    ProviderNotFound: IDL.Null,
+    NoPermission: IDL.Null,
+  });
+  const ValidationError = IDL.Variant({
+    Custom: IDL.Text,
+    InvalidHex: IDL.Text,
+  });
+  const RejectionCode = IDL.Variant({
+    NoError: IDL.Null,
+    CanisterError: IDL.Null,
+    SysTransient: IDL.Null,
+    DestinationInvalid: IDL.Null,
+    Unknown: IDL.Null,
+    SysFatal: IDL.Null,
+    CanisterReject: IDL.Null,
+  });
+  const HttpOutcallError = IDL.Variant({
+    IcError: IDL.Record({ code: RejectionCode, message: IDL.Text }),
+    InvalidHttpJsonRpcResponse: IDL.Record({
+      status: IDL.Nat16,
+      body: IDL.Text,
+      parsingError: IDL.Opt(IDL.Text),
+    }),
+  });
+  const RpcError = IDL.Variant({
+    JsonRpcError: JsonRpcError,
+    ProviderError: ProviderError,
+    ValidationError: ValidationError,
+    HttpOutcallError: HttpOutcallError,
+  });
+  const CallResult = IDL.Variant({ Ok: IDL.Text, Err: RpcError });
+  const ProviderId = IDL.Nat64;
+  const RpcService = IDL.Variant({
+    EthSepolia: EthSepoliaService,
+    BaseMainnet: L2MainnetService,
+    Custom: RpcApi,
+    OptimismMainnet: L2MainnetService,
+    ArbitrumOne: L2MainnetService,
+    EthMainnet: EthMainnetService,
+    Provider: ProviderId,
+  });
+  const MultiCallResult = IDL.Variant({
+    Consistent: CallResult,
+    Inconsistent: IDL.Vec(IDL.Tuple(RpcService, CallResult)),
+  });
+  const FeeHistoryArgs = IDL.Record({
+    blockCount: IDL.Nat,
+    newestBlock: BlockTag,
+    rewardPercentiles: IDL.Opt(IDL.Vec(IDL.Nat8)),
+  });
+  const FeeHistory = IDL.Record({
+    reward: IDL.Vec(IDL.Vec(IDL.Nat)),
+    gasUsedRatio: IDL.Vec(IDL.Float64),
+    oldestBlock: IDL.Nat,
+    baseFeePerGas: IDL.Vec(IDL.Nat),
+  });
+  const FeeHistoryResult = IDL.Variant({ Ok: FeeHistory, Err: RpcError });
+  const MultiFeeHistoryResult = IDL.Variant({
+    Consistent: FeeHistoryResult,
+    Inconsistent: IDL.Vec(IDL.Tuple(RpcService, FeeHistoryResult)),
+  });
+  const Block = IDL.Record({
+    miner: IDL.Text,
+    totalDifficulty: IDL.Opt(IDL.Nat),
+    receiptsRoot: IDL.Text,
+    stateRoot: IDL.Text,
+    hash: IDL.Text,
+    difficulty: IDL.Opt(IDL.Nat),
+    size: IDL.Nat,
+    uncles: IDL.Vec(IDL.Text),
+    baseFeePerGas: IDL.Opt(IDL.Nat),
+    extraData: IDL.Text,
+    transactionsRoot: IDL.Opt(IDL.Text),
+    sha3Uncles: IDL.Text,
+    nonce: IDL.Nat,
+    number: IDL.Nat,
+    timestamp: IDL.Nat,
+    transactions: IDL.Vec(IDL.Text),
+    gasLimit: IDL.Nat,
+    logsBloom: IDL.Text,
+    parentHash: IDL.Text,
+    gasUsed: IDL.Nat,
+    mixHash: IDL.Text,
+  });
+  const GetBlockByNumberResult = IDL.Variant({
+    Ok: Block,
+    Err: RpcError,
+  });
+  const MultiGetBlockByNumberResult = IDL.Variant({
+    Consistent: GetBlockByNumberResult,
+    Inconsistent: IDL.Vec(IDL.Tuple(RpcService, GetBlockByNumberResult)),
+  });
+  const Topic = IDL.Vec(IDL.Text);
+  const GetLogsArgs = IDL.Record({
+    fromBlock: IDL.Opt(BlockTag),
+    toBlock: IDL.Opt(BlockTag),
+    addresses: IDL.Vec(IDL.Text),
+    topics: IDL.Opt(IDL.Vec(Topic)),
+  });
+  const LogEntry = IDL.Record({
+    transactionHash: IDL.Opt(IDL.Text),
+    blockNumber: IDL.Opt(IDL.Nat),
+    data: IDL.Text,
+    blockHash: IDL.Opt(IDL.Text),
+    transactionIndex: IDL.Opt(IDL.Nat),
+    topics: IDL.Vec(IDL.Text),
+    address: IDL.Text,
+    logIndex: IDL.Opt(IDL.Nat),
+    removed: IDL.Bool,
+  });
+  const GetLogsResult = IDL.Variant({
+    Ok: IDL.Vec(LogEntry),
+    Err: RpcError,
+  });
+  const MultiGetLogsResult = IDL.Variant({
+    Consistent: GetLogsResult,
+    Inconsistent: IDL.Vec(IDL.Tuple(RpcService, GetLogsResult)),
+  });
+  const GetTransactionCountArgs = IDL.Record({
+    address: IDL.Text,
+    block: BlockTag,
+  });
+  const GetTransactionCountResult = IDL.Variant({
+    Ok: IDL.Nat,
+    Err: RpcError,
+  });
+  const MultiGetTransactionCountResult = IDL.Variant({
+    Consistent: GetTransactionCountResult,
+    Inconsistent: IDL.Vec(IDL.Tuple(RpcService, GetTransactionCountResult)),
+  });
+  const TransactionReceipt = IDL.Record({
+    to: IDL.Opt(IDL.Text),
+    status: IDL.Opt(IDL.Nat),
+    transactionHash: IDL.Text,
+    blockNumber: IDL.Nat,
+    from: IDL.Text,
+    logs: IDL.Vec(LogEntry),
+    blockHash: IDL.Text,
+    type: IDL.Text,
+    transactionIndex: IDL.Nat,
+    effectiveGasPrice: IDL.Nat,
+    logsBloom: IDL.Text,
+    contractAddress: IDL.Opt(IDL.Text),
+    gasUsed: IDL.Nat,
+  });
+  const GetTransactionReceiptResult = IDL.Variant({
+    Ok: IDL.Opt(TransactionReceipt),
+    Err: RpcError,
+  });
+  const MultiGetTransactionReceiptResult = IDL.Variant({
+    Consistent: GetTransactionReceiptResult,
+    Inconsistent: IDL.Vec(IDL.Tuple(RpcService, GetTransactionReceiptResult)),
+  });
+  const SendRawTransactionStatus = IDL.Variant({
+    Ok: IDL.Opt(IDL.Text),
+    NonceTooLow: IDL.Null,
+    NonceTooHigh: IDL.Null,
+    InsufficientFunds: IDL.Null,
+  });
+  const SendRawTransactionResult = IDL.Variant({
+    Ok: SendRawTransactionStatus,
+    Err: RpcError,
+  });
+  const MultiSendRawTransactionResult = IDL.Variant({
+    Consistent: SendRawTransactionResult,
+    Inconsistent: IDL.Vec(IDL.Tuple(RpcService, SendRawTransactionResult)),
   });
   const Nonce = IDL.Record({ nonce: IDL.Nat, timestamp: IDL.Int });
   const Origin = IDL.Record({
@@ -120,11 +389,7 @@ export const idlFactory = ({ IDL }) => {
   const InstallArgs = IDL.Record({
     arg: IDL.Vec(IDL.Nat8),
     wasm_module: IDL.Vec(IDL.Nat8),
-    mode: IDL.Variant({
-      reinstall: IDL.Null,
-      upgrade: IDL.Null,
-      install: IDL.Null,
-    }),
+    mode: canister_install_mode,
     canister_id: IDL.Principal,
   });
   const InstallConfig = IDL.Record({
@@ -141,18 +406,37 @@ export const idlFactory = ({ IDL }) => {
     total_size: IDL.Nat64,
     taken_at_timestamp: IDL.Nat64,
   });
+  const RequestResult = IDL.Variant({ Ok: IDL.Text, Err: RpcError });
+  const ecdsa_curve = IDL.Variant({ secp256k1: IDL.Null });
+  const sign_with_ecdsa_args = IDL.Record({
+    key_id: IDL.Record({ name: IDL.Text, curve: ecdsa_curve }),
+    derivation_path: IDL.Vec(IDL.Vec(IDL.Nat8)),
+    message_hash: IDL.Vec(IDL.Nat8),
+  });
+  const sign_with_ecdsa_result = IDL.Record({
+    signature: IDL.Vec(IDL.Nat8),
+  });
+  const schnorr_aux = IDL.Variant({
+    bip341: IDL.Record({ merkle_root_hash: IDL.Vec(IDL.Nat8) }),
+  });
+  const schnorr_algorithm = IDL.Variant({
+    ed25519: IDL.Null,
+    bip340secp256k1: IDL.Null,
+  });
+  const sign_with_schnorr_args = IDL.Record({
+    aux: IDL.Opt(schnorr_aux),
+    key_id: IDL.Record({
+      algorithm: schnorr_algorithm,
+      name: IDL.Text,
+    }),
+    derivation_path: IDL.Vec(IDL.Vec(IDL.Nat8)),
+    message: IDL.Vec(IDL.Nat8),
+  });
+  const sign_with_schnorr_result = IDL.Record({
+    signature: IDL.Vec(IDL.Nat8),
+  });
   const Self = IDL.Service({
     GCCanisters: IDL.Func([], [], ["oneway"]),
-    __transform: IDL.Func(
-      [
-        IDL.Record({
-          context: IDL.Vec(IDL.Nat8),
-          response: http_request_result,
-        }),
-      ],
-      [http_request_result],
-      ["composite_query"],
-    ),
     _ttp_request: IDL.Func([http_request_args], [http_request_result], []),
     balance: IDL.Func([], [IDL.Nat], ["query"]),
     callForward: IDL.Func(
@@ -188,17 +472,45 @@ export const idlFactory = ({ IDL }) => {
     ),
     deployCanister: IDL.Func(
       [IDL.Opt(CanisterInfo), IDL.Opt(DeployArgs)],
-      [
-        CanisterInfo,
-        IDL.Variant({
-          reinstall: IDL.Null,
-          upgrade: IDL.Null,
-          install: IDL.Null,
-        }),
-      ],
+      [CanisterInfo, canister_install_mode],
       [],
     ),
     dump: IDL.Func([], [IDL.Vec(CanisterInfo)], ["query"]),
+    eth_call: IDL.Func(
+      [RpcServices, IDL.Opt(RpcConfig), CallArgs],
+      [MultiCallResult],
+      [],
+    ),
+    eth_feeHistory: IDL.Func(
+      [RpcServices, IDL.Opt(RpcConfig), FeeHistoryArgs],
+      [MultiFeeHistoryResult],
+      [],
+    ),
+    eth_getBlockByNumber: IDL.Func(
+      [RpcServices, IDL.Opt(RpcConfig), BlockTag],
+      [MultiGetBlockByNumberResult],
+      [],
+    ),
+    eth_getLogs: IDL.Func(
+      [RpcServices, IDL.Opt(RpcConfig), GetLogsArgs],
+      [MultiGetLogsResult],
+      [],
+    ),
+    eth_getTransactionCount: IDL.Func(
+      [RpcServices, IDL.Opt(RpcConfig), GetTransactionCountArgs],
+      [MultiGetTransactionCountResult],
+      [],
+    ),
+    eth_getTransactionReceipt: IDL.Func(
+      [RpcServices, IDL.Opt(RpcConfig), IDL.Text],
+      [MultiGetTransactionReceiptResult],
+      [],
+    ),
+    eth_sendRawTransaction: IDL.Func(
+      [RpcServices, IDL.Opt(RpcConfig), IDL.Text],
+      [MultiSendRawTransactionResult],
+      [],
+    ),
     getCanisterId: IDL.Func([Nonce, Origin], [CanisterInfo], []),
     getInitParams: IDL.Func([], [InitParams], ["query"]),
     getStats: IDL.Func(
@@ -232,11 +544,7 @@ export const idlFactory = ({ IDL }) => {
         IDL.Record({
           arg: IDL.Vec(IDL.Nat8),
           wasm_module: wasm_module,
-          mode: IDL.Variant({
-            reinstall: IDL.Null,
-            upgrade: IDL.Null,
-            install: IDL.Null,
-          }),
+          mode: canister_install_mode,
           canister_id: canister_id,
         }),
       ],
@@ -254,7 +562,18 @@ export const idlFactory = ({ IDL }) => {
     mergeTags: IDL.Func([IDL.Text, IDL.Opt(IDL.Text)], [], []),
     releaseAllCanisters: IDL.Func([], [], []),
     removeCode: IDL.Func([CanisterInfo], [], []),
+    request: IDL.Func([RpcService, IDL.Text, IDL.Nat64], [RequestResult], []),
     resetStats: IDL.Func([], [], []),
+    sign_with_ecdsa: IDL.Func(
+      [sign_with_ecdsa_args],
+      [sign_with_ecdsa_result],
+      [],
+    ),
+    sign_with_schnorr: IDL.Func(
+      [sign_with_schnorr_args],
+      [sign_with_schnorr_result],
+      [],
+    ),
     start_canister: IDL.Func(
       [IDL.Record({ canister_id: canister_id })],
       [],
@@ -293,12 +612,17 @@ export const idlFactory = ({ IDL }) => {
   return Self;
 };
 export const init = ({ IDL }) => {
+  const CyclesSettings = IDL.Record({
+    max_cycles_per_call: IDL.Nat,
+    max_cycles_total: IDL.Nat,
+  });
   const InitParams = IDL.Record({
     max_num_canisters: IDL.Nat,
     canister_time_to_live: IDL.Nat,
     stored_module: IDL.Opt(
       IDL.Record({ arg: IDL.Vec(IDL.Nat8), hash: IDL.Vec(IDL.Nat8) }),
     ),
+    cycles_settings: IDL.Opt(CyclesSettings),
     wasm_utils_principal: IDL.Opt(IDL.Text),
     cycles_per_canister: IDL.Nat,
     admin_only: IDL.Opt(IDL.Bool),


### PR DESCRIPTION
This PR changes the pool canister to not redirect the transform function using a composite query. This PR can only be merged after https://github.com/dfinity/ic/pull/4800 is rolled out in production.