### PR TITLE
chore: disable canister http

### DIFF
--- a/src/declarations/backend/backend.did
+++ b/src/declarations/backend/backend.did
@@ -95,10 +95,6 @@ type Stats =
 type Self = 
  service {
    GCCanisters: () -> () oneway;
-   __transform: (record {
-                   context: blob;
-                   response: http_request_result;
-                 }) -> (http_request_result) composite_query;
    _ttp_request: (http_request_args) -> (http_request_result);
    balance: () -> (nat) query;
    callForward: (CanisterInfo, text, blob) -> (blob);

--- a/src/declarations/backend/backend.did.d.ts
+++ b/src/declarations/backend/backend.did.d.ts
@@ -57,10 +57,6 @@ export interface Origin {
 }
 export interface Self {
   GCCanisters: ActorMethod<[], undefined>;
-  __transform: ActorMethod<
-    [{ context: Uint8Array | number[]; response: http_request_result }],
-    http_request_result
-  >;
   _ttp_request: ActorMethod<[http_request_args], http_request_result>;
   balance: ActorMethod<[], bigint>;
   callForward: ActorMethod<

--- a/src/declarations/backend/backend.did.js
+++ b/src/declarations/backend/backend.did.js
@@ -143,16 +143,6 @@ export const idlFactory = ({ IDL }) => {
   });
   const Self = IDL.Service({
     GCCanisters: IDL.Func([], [], ["oneway"]),
-    __transform: IDL.Func(
-      [
-        IDL.Record({
-          context: IDL.Vec(IDL.Nat8),
-          response: http_request_result,
-        }),
-      ],
-      [http_request_result],
-      ["composite_query"],
-    ),
     _ttp_request: IDL.Func([http_request_args], [http_request_result], []),
     balance: IDL.Func([], [IDL.Nat], ["query"]),
     callForward: IDL.Func(


### PR DESCRIPTION
This PR disables canister http outcalls by rejecting such calls with the reject code `CanisterError` and the reject message
```
IC0503: Error from Canister mwrha-maaaa-aaaab-qabqq-cai: Canister called `ic0.trap` with message: \'Canister http outcalls are disabled\'.\nConsider gracefully handling failures from this canister or altering the canister to handle exceptions. See documentation: https://internetcomputer.org/docs/current/references/execution-errors#trapped-explicitly
```